### PR TITLE
Add optional chars argument to String#strip, #lstrip, and #rstrip

### DIFF
--- a/string.c
+++ b/string.c
@@ -10224,7 +10224,7 @@ lstrip_offset(VALUE str, const char *s, const char *e, rb_encoding *enc, VALUE c
             int n;
             unsigned int cc = rb_enc_codepoint_len(s, e, &n, enc);
 
-            if (cc && !tr_find(cc, table, del, nodel)) break;
+            if (!tr_find(cc, table, del, nodel)) break;
             s += n;
         }
         return s - start;

--- a/string.c
+++ b/string.c
@@ -10210,7 +10210,7 @@ lstrip_offset(VALUE str, const char *s, const char *e, rb_encoding *enc, VALUE c
 
     if (!s || s >= e) return 0;
 
-    /* remove chars at head if given */
+    /* remove leading chars if given */
     if (!NIL_P(chars)) {
         char table[TR_TABLE_SIZE];
         VALUE del = 0, nodel = 0;

--- a/string.c
+++ b/string.c
@@ -10297,8 +10297,7 @@ rb_str_lstrip_bang(int argc, VALUE *argv, VALUE str)
  *    s.lstrip
  *    # => "abc\u0000\t\n\v\f\r "
  *
- *  When the optional +chars+ argument is provided, removes characters
- *  in +chars+ from the beginning of +self+:
+ *  If +chars+ is given, removes characters in +chars+ from the beginning of +self+:
  *
  *    s = "---abc+++"
  *    s.lstrip("-") # => "abc+++"
@@ -10419,8 +10418,7 @@ rb_str_rstrip_bang(int argc, VALUE *argv, VALUE str)
  *    s        # => "\u0000\t\n\v\f\r abc\u0000\t\n\v\f\r "
  *    s.rstrip # => "\u0000\t\n\v\f\r abc"
  *
- *  When the optional +chars+ argument is provided, removes characters
- *  in +chars+ from the end of +self+:
+ *  If +chars+ is given, removes characters in +chars+ from the end of +self+:
  *
  *    s = "---abc+++"
  *    s.rstrip("+") # => "---abc"
@@ -10501,8 +10499,7 @@ rb_str_strip_bang(int argc, VALUE *argv, VALUE str)
  *    # => "\u0000\t\n\v\f\r abc\u0000\t\n\v\f\r "
  *    s.strip # => "abc"
  *
- *  When the optional +chars+ argument is provided, removes characters
- *  in +chars+ from both ends of +self+:
+ *  If +chars+ is given, removes characters in +chars+ from both ends of +self+:
  *
  *    s = "---abc+++"
  *    s.strip("-+") # => "abc"

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2034,6 +2034,88 @@ CODE
     assert_equal(S("x") ,a)
   end
 
+  def test_strip_with_chars
+    assert_equal(S("abc"), S("---abc+++").strip("-+"))
+    assert_equal(S("abc"), S("+++abc---").strip("-+"))
+    assert_equal(S("abc"), S("+-+abc-+-").strip("-+"))
+    assert_equal(S(""), S("---+++").strip("-+"))
+    assert_equal(S("abc   "), S("---abc   ").strip("-"))
+    assert_equal(S("   abc"), S("   abc+++").strip("+"))
+
+    # Test with multibyte characters
+    assert_equal(S("abc"), S("あああabcいいい").strip("あい"))
+    assert_equal(S("abc"), S("いいいabcあああ").strip("あい"))
+
+    # Test without modification
+    assert_equal(S("abc"), S("abc").strip("-+"))
+    assert_equal(S("abc"), S("abc").strip(""))
+  end
+
+  def test_strip_bang_with_chars
+    a = S("---abc+++")
+    assert_equal(S("abc"), a.strip!("-+"))
+    assert_equal(S("abc"), a)
+
+    a = S("+++abc---")
+    assert_equal(S("abc"), a.strip!("-+"))
+    assert_equal(S("abc"), a)
+
+    a = S("abc")
+    assert_nil(a.strip!("-+"))
+    assert_equal(S("abc"), a)
+
+    # Test with multibyte characters
+    a = S("あああabcいいい")
+    assert_equal(S("abc"), a.strip!("あい"))
+    assert_equal(S("abc"), a)
+  end
+
+  def test_lstrip_with_chars
+    assert_equal(S("abc+++"), S("---abc+++").lstrip("-"))
+    assert_equal(S("abc---"), S("+++abc---").lstrip("+"))
+    assert_equal(S("abc"), S("---abc").lstrip("-"))
+    assert_equal(S(""), S("---").lstrip("-"))
+
+    # Test with multibyte characters
+    assert_equal(S("abcいいい"), S("あああabcいいい").lstrip("あ"))
+
+    # Test without modification
+    assert_equal(S("abc"), S("abc").lstrip("-"))
+  end
+
+  def test_lstrip_bang_with_chars
+    a = S("---abc+++")
+    assert_equal(S("abc+++"), a.lstrip!("-"))
+    assert_equal(S("abc+++"), a)
+
+    a = S("abc")
+    assert_nil(a.lstrip!("-"))
+    assert_equal(S("abc"), a)
+  end
+
+  def test_rstrip_with_chars
+    assert_equal(S("---abc"), S("---abc+++").rstrip("+"))
+    assert_equal(S("+++abc"), S("+++abc---").rstrip("-"))
+    assert_equal(S("abc"), S("abc+++").rstrip("+"))
+    assert_equal(S(""), S("+++").rstrip("+"))
+
+    # Test with multibyte characters
+    assert_equal(S("あああabc"), S("あああabcいいい").rstrip("い"))
+
+    # Test without modification
+    assert_equal(S("abc"), S("abc").rstrip("-"))
+  end
+
+  def test_rstrip_bang_with_chars
+    a = S("---abc+++")
+    assert_equal(S("---abc"), a.rstrip!("+"))
+    assert_equal(S("---abc"), a)
+
+    a = S("abc")
+    assert_nil(a.rstrip!("+"))
+    assert_equal(S("abc"), a)
+  end
+
   def test_sub
     assert_equal(S("h*llo"),    S("hello").sub(/[aeiou]/, S('*')))
     assert_equal(S("h<e>llo"),  S("hello").sub(/([aeiou])/, S('<\1>')))

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2046,6 +2046,10 @@ CODE
     assert_equal(S("abc"), S("あああabcいいい").strip("あい"))
     assert_equal(S("abc"), S("いいいabcあああ").strip("あい"))
 
+    # Test with NUL characters
+    assert_equal(S("abc\0"), S("---abc\0--").strip("-"))
+    assert_equal(S("\0abc"), S("--\0abc---").strip("-"))
+
     # Test without modification
     assert_equal(S("abc"), S("abc").strip("-+"))
     assert_equal(S("abc"), S("abc").strip(""))
@@ -2079,6 +2083,9 @@ CODE
     # Test with multibyte characters
     assert_equal(S("abcいいい"), S("あああabcいいい").lstrip("あ"))
 
+    # Test with NUL characters
+    assert_equal(S("\0abc+++"), S("--\0abc+++").lstrip("-"))
+
     # Test without modification
     assert_equal(S("abc"), S("abc").lstrip("-"))
   end
@@ -2101,6 +2108,9 @@ CODE
 
     # Test with multibyte characters
     assert_equal(S("あああabc"), S("あああabcいいい").rstrip("い"))
+
+    # Test with NUL characters
+    assert_equal(S("---abc\0"), S("---abc\0++").rstrip("+"))
 
     # Test without modification
     assert_equal(S("abc"), S("abc").rstrip("-"))


### PR DESCRIPTION
This enhancement allows specifying a custom set of characters to remove from strings instead of only whitespace characters.

Examples:
  "---abc+++".strip("-+")  # => "abc"
  "---abc+++".lstrip("-")  # => "abc+++"
  "---abc+++".rstrip("+")  # => "---abc"

The implementation:
- Adds char_in_string() helper to check if a character is in the set
- Adds lstrip_offset_chars() and rstrip_offset_chars() for custom char removal
- Updates strip, lstrip, rstrip and their bang variants to accept optional chars arg
- Maintains backward compatibility when no argument is provided
- Properly handles multibyte characters with encoding awareness

🤖 Generated with [Claude Code](https://claude.com/claude-code)