### PR TITLE
Add Proc#with_refinements

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -13673,7 +13673,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     const int parent_iseq_index =           ibf_dump_iseq(dump, ISEQ_BODY(iseq)->parent_iseq);
     const int local_iseq_index =            ibf_dump_iseq(dump, ISEQ_BODY(iseq)->local_iseq);
     /* For block iseqs this slot holds the (transient, non-serialized)
-     * Proc#dup_with_refinements memo rather than a mandatory_only_iseq, so dump
+     * Proc#with_refinements memo rather than a mandatory_only_iseq, so dump
      * it as absent. */
     const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK ? NULL : ISEQ_BODY(iseq)->opt.mandatory_only_iseq);
     const ibf_offset_t ci_entries_offset =  ibf_dump_ci_entries(dump, iseq);

--- a/compile.c
+++ b/compile.c
@@ -9382,7 +9382,7 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
                            nd_line(line_node), NULL, 0,
                            ISEQ_TYPE_METHOD, ISEQ_COMPILE_DATA(iseq)->option,
                            ISEQ_BODY(iseq)->variable.script_lines);
-    RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->mandatory_only_iseq, (VALUE)mandatory_only_iseq);
+    RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->opt.mandatory_only_iseq, (VALUE)mandatory_only_iseq);
 
     ALLOCV_END(idtmp);
     return COMPILE_OK;
@@ -13675,7 +13675,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     /* For block iseqs this slot holds the (transient, non-serialized)
      * Proc#dup_with_refinements memo rather than a mandatory_only_iseq, so dump
      * it as absent. */
-    const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK ? NULL : ISEQ_BODY(iseq)->mandatory_only_iseq);
+    const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK ? NULL : ISEQ_BODY(iseq)->opt.mandatory_only_iseq);
     const ibf_offset_t ci_entries_offset =  ibf_dump_ci_entries(dump, iseq);
     const ibf_offset_t outer_variables_offset = ibf_dump_outer_variables(dump, iseq);
 
@@ -13978,7 +13978,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
 
     RB_OBJ_WRITE(iseq, &load_body->parent_iseq, parent_iseq);
     RB_OBJ_WRITE(iseq, &load_body->local_iseq, local_iseq);
-    RB_OBJ_WRITE(iseq, &load_body->mandatory_only_iseq, mandatory_only_iseq);
+    RB_OBJ_WRITE(iseq, &load_body->opt.mandatory_only_iseq, mandatory_only_iseq);
 
     // This must be done after the local table is loaded.
     if (load_body->param.keyword != NULL) {

--- a/compile.c
+++ b/compile.c
@@ -13672,7 +13672,10 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     const ibf_offset_t catch_table_offset = ibf_dump_catch_table(dump, iseq);
     const int parent_iseq_index =           ibf_dump_iseq(dump, ISEQ_BODY(iseq)->parent_iseq);
     const int local_iseq_index =            ibf_dump_iseq(dump, ISEQ_BODY(iseq)->local_iseq);
-    const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->mandatory_only_iseq);
+    /* For block iseqs this slot holds the (transient, non-serialized)
+     * Proc#dup_with_refinements memo rather than a mandatory_only_iseq, so dump
+     * it as absent. */
+    const int mandatory_only_iseq_index =   ibf_dump_iseq(dump, ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK ? NULL : ISEQ_BODY(iseq)->mandatory_only_iseq);
     const ibf_offset_t ci_entries_offset =  ibf_dump_ci_entries(dump, iseq);
     const ibf_offset_t outer_variables_offset = ibf_dump_outer_variables(dump, iseq);
 

--- a/compile.c
+++ b/compile.c
@@ -975,7 +975,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     return iseq_setup(iseq, ret);
 }
 
-static int
+int
 rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 {
 #if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE

--- a/cont.c
+++ b/cont.c
@@ -2657,7 +2657,8 @@ rb_fiber_start(rb_fiber_t *fiber)
         th->ec->root_svar = Qfalse;
 
         EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_FIBER_SWITCH, th->self, 0, 0, 0, Qnil);
-        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE);
+        cont->value = rb_vm_invoke_proc(th->ec, proc, argc, argv, cont->kw_splat, VM_BLOCK_HANDLER_NONE,
+                                        proc->has_refinements ? rb_proc_refinements_cref(fiber->first_proc) : NULL);
     }
     EC_POP_TAG();
 

--- a/eval.c
+++ b/eval.c
@@ -1483,8 +1483,10 @@ using_module_recursive(const rb_cref_t *cref, VALUE klass)
 
 /*!
  * \private
+ * Activate the refinements of \a module in \a cref, as the top-level `using`
+ * does for the current cref.  Also used by Proc#dup_with_refinements.
  */
-static void
+void
 rb_using_module(const rb_cref_t *cref, VALUE module)
 {
     Check_Type(module, T_MODULE);

--- a/eval.c
+++ b/eval.c
@@ -1451,15 +1451,23 @@ using_refinement(VALUE klass, VALUE module, VALUE arg)
     return ST_CONTINUE;
 }
 
-static void
-using_module_recursive(const rb_cref_t *cref, VALUE klass)
+/*!
+ * \private
+ * Activate the refinements of \a klass (a module, or an ancestor of one during
+ * recursion) in \a cref, without flushing the global refinement method caches.
+ * rb_using_module wraps this with the flush, which is needed when \a cref is
+ * already associated with live call sites.  Proc#dup_with_refinements uses this
+ * directly because it builds a fresh cref that no call site references yet.
+ */
+void
+rb_using_module_recursive(rb_cref_t *cref, VALUE klass)
 {
     ID id_refinements;
     VALUE super, module, refinements;
 
     super = RCLASS_SUPER(klass);
     if (super) {
-        using_module_recursive(cref, super);
+        rb_using_module_recursive(cref, super);
     }
     switch (BUILTIN_TYPE(klass)) {
       case T_MODULE:
@@ -1483,14 +1491,12 @@ using_module_recursive(const rb_cref_t *cref, VALUE klass)
 
 /*!
  * \private
- * Activate the refinements of \a module in \a cref, as the top-level `using`
- * does for the current cref.  Also used by Proc#dup_with_refinements.
  */
-void
-rb_using_module(const rb_cref_t *cref, VALUE module)
+static void
+rb_using_module(rb_cref_t *cref, VALUE module)
 {
     Check_Type(module, T_MODULE);
-    using_module_recursive(cref, module);
+    rb_using_module_recursive(cref, module);
     rb_clear_all_refinement_method_cache();
 }
 

--- a/eval.c
+++ b/eval.c
@@ -1456,7 +1456,7 @@ using_refinement(VALUE klass, VALUE module, VALUE arg)
  * Activate the refinements of \a klass (a module, or an ancestor of one during
  * recursion) in \a cref, without flushing the global refinement method caches.
  * rb_using_module wraps this with the flush, which is needed when \a cref is
- * already associated with live call sites.  Proc#dup_with_refinements uses this
+ * already associated with live call sites.  Proc#with_refinements uses this
  * directly because it builds a fresh cref that no call site references yet.
  */
 void

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -30,6 +30,8 @@ NORETURN(VALUE rb_f_raise(int argc, VALUE *argv));
 VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
 void rb_vm_using_module(VALUE module);
+void rb_using_module(const rb_cref_t *cref, VALUE module);
+rb_cref_t *rb_vm_cref_dup(const rb_cref_t *cref);
 VALUE rb_top_main_class(const char *method);
 VALUE rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2);
 

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -31,7 +31,6 @@ VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
 void rb_vm_using_module(VALUE module);
 void rb_using_module_recursive(rb_cref_t *cref, VALUE module);
-rb_cref_t *rb_vm_cref_dup(const rb_cref_t *cref);
 VALUE rb_top_main_class(const char *method);
 VALUE rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2);
 

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -30,7 +30,7 @@ NORETURN(VALUE rb_f_raise(int argc, VALUE *argv));
 VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
 void rb_vm_using_module(VALUE module);
-void rb_using_module(const rb_cref_t *cref, VALUE module);
+void rb_using_module_recursive(rb_cref_t *cref, VALUE module);
 rb_cref_t *rb_vm_cref_dup(const rb_cref_t *cref);
 VALUE rb_top_main_class(const char *method);
 VALUE rb_ec_ensure(rb_execution_context_t *ec, VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*e_proc)(VALUE), VALUE data2);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -24,6 +24,7 @@
 
 struct rb_callable_method_entry_struct; /* in method.h */
 struct rb_method_definition_struct;     /* in method.h */
+struct rb_cref_struct;                  /* in method.h */
 struct rb_execution_context_struct;     /* in vm_core.h */
 struct rb_control_frame_struct;         /* in vm_core.h */
 struct rb_callinfo;                     /* in vm_core.h */
@@ -55,6 +56,7 @@ void rb_vm_pop_cfunc_frame(void);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
+struct rb_cref_struct *rb_vm_cref_dup(const struct rb_cref_struct *cref);
 VALUE ruby_vm_special_exception_copy(VALUE);
 
 void rb_lastline_set_up(VALUE val, unsigned int up);

--- a/iseq.c
+++ b/iseq.c
@@ -619,19 +619,30 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
                               long argc, const VALUE *mods,
                               const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
 {
+    /* Allocate the key array up front: this (and ZALLOC below) can trigger a
+     * GC, which marks the live memo through its source iseq.  By keeping the
+     * memo consistent (argc matches mods) whenever it is reachable from
+     * body->refinement_memo, the mark never sees argc > 0 with a stale/NULL
+     * mods. */
+    VALUE *new_mods = ALLOC_N(VALUE, argc);
+    MEMCPY(new_mods, mods, VALUE, argc);
+
     struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
     struct rb_iseq_refinement_memo *memo = body->refinement_memo;
     if (memo == NULL) {
+        /* Zeroed (argc == 0, mods == NULL), so it is safe to mark before it is
+         * fully populated below. */
         memo = ZALLOC(struct rb_iseq_refinement_memo);
         body->refinement_memo = memo;
     }
     else {
         ruby_xfree(memo->mods);
     }
+    /* Plain stores from here on (no allocation, no GC): the memo transitions
+     * directly from its previous consistent state to the new one. */
     memo->base_cref = base_cref;
     memo->argc = argc;
-    memo->mods = ALLOC_N(VALUE, argc);
-    MEMCPY(memo->mods, mods, VALUE, argc);
+    memo->mods = new_mods;
     memo->copied_iseq = copied_iseq;
     memo->cref = cref;
 

--- a/iseq.c
+++ b/iseq.c
@@ -237,7 +237,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
         /* refinement_memo shares a slot with mandatory_only_iseq (a GC object,
          * not owned here); only block iseqs hold a memo to free. */
-        if (body->type == ISEQ_TYPE_BLOCK) iseq_refinement_memo_free(body->refinement_memo);
+        if (body->type == ISEQ_TYPE_BLOCK) iseq_refinement_memo_free(body->opt.refinement_memo);
         SIZED_FREE(body);
     }
 
@@ -323,7 +323,7 @@ iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen)
     body->variable.coverage = Qnil;
     body->variable.pc2branchindex = Qnil;
     body->variable.original_iseq = NULL;
-    body->refinement_memo = NULL;
+    body->opt.refinement_memo = NULL;
 
     const unsigned int iseq_size = src_body->iseq_size;
     const unsigned int is_size = ISEQ_IS_SIZE(src_body);
@@ -602,7 +602,7 @@ rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_
                                long argc, const VALUE *mods,
                                const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
 {
-    const struct rb_iseq_refinement_memo *memo = ISEQ_BODY(src_iseq)->refinement_memo;
+    const struct rb_iseq_refinement_memo *memo = ISEQ_BODY(src_iseq)->opt.refinement_memo;
     if (memo && iseq_refinement_memo_key_match(memo, base_cref, argc, mods)) {
         *iseq_out = memo->copied_iseq;
         *cref_out = memo->cref;
@@ -621,7 +621,7 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
     /* Allocate the key array up front: this (and ZALLOC below) can trigger a
      * GC, which marks the live memo through its source iseq.  By keeping the
      * memo consistent (argc matches mods) whenever it is reachable from
-     * body->refinement_memo, the mark never sees argc > 0 with a stale/NULL
+     * body->opt.refinement_memo, the mark never sees argc > 0 with a stale/NULL
      * mods. */
     VALUE *new_mods = ALLOC_N(VALUE, argc);
     MEMCPY(new_mods, mods, VALUE, argc);
@@ -630,12 +630,12 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
     /* The memo shares storage with mandatory_only_iseq, discriminated by the
      * iseq type; dup_with_refinements sources are always block iseqs. */
     VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
-    struct rb_iseq_refinement_memo *memo = body->refinement_memo;
+    struct rb_iseq_refinement_memo *memo = body->opt.refinement_memo;
     if (memo == NULL) {
         /* Zeroed (argc == 0, mods == NULL), so it is safe to mark before it is
          * fully populated below. */
         memo = ZALLOC(struct rb_iseq_refinement_memo);
-        body->refinement_memo = memo;
+        body->opt.refinement_memo = memo;
     }
     else {
         ruby_xfree(memo->mods);
@@ -811,8 +811,8 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
         /* mandatory_only_iseq and refinement_memo share a slot (see vm_core.h);
          * the iseq type selects which one is live. */
         if (body->type == ISEQ_TYPE_BLOCK) {
-            if (body->refinement_memo) {
-                struct rb_iseq_refinement_memo *memo = body->refinement_memo;
+            if (body->opt.refinement_memo) {
+                struct rb_iseq_refinement_memo *memo = body->opt.refinement_memo;
                 if (memo->base_cref) rb_gc_mark_and_move((VALUE *)&memo->base_cref);
                 if (memo->cref) rb_gc_mark_and_move((VALUE *)&memo->cref);
                 if (memo->copied_iseq) rb_gc_mark_and_move_ptr(&memo->copied_iseq);
@@ -821,8 +821,8 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
                 }
             }
         }
-        else if (body->mandatory_only_iseq) {
-            rb_gc_mark_and_move_ptr(&body->mandatory_only_iseq);
+        else if (body->opt.mandatory_only_iseq) {
+            rb_gc_mark_and_move_ptr(&body->opt.mandatory_only_iseq);
         }
 
         if (body->call_data) {
@@ -969,9 +969,9 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
 
         /* refinement_memo shares a slot with mandatory_only_iseq; only block
          * iseqs hold a memo. */
-        if (body->type == ISEQ_TYPE_BLOCK && body->refinement_memo) {
+        if (body->type == ISEQ_TYPE_BLOCK && body->opt.refinement_memo) {
             size += sizeof(struct rb_iseq_refinement_memo);
-            size += body->refinement_memo->argc * sizeof(VALUE);
+            size += body->opt.refinement_memo->argc * sizeof(VALUE);
         }
     }
 

--- a/iseq.c
+++ b/iseq.c
@@ -181,6 +181,8 @@ rb_iseq_local_hooks(const rb_iseq_t *iseq, rb_ractor_t *r, bool create)
     return hook_list;
 }
 
+static void iseq_refinement_memo_free(struct rb_iseq_refinement_memo *memo);
+
 void
 rb_iseq_free(const rb_iseq_t *iseq)
 {
@@ -233,6 +235,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
         compile_data_free(ISEQ_COMPILE_DATA(iseq));
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
+        iseq_refinement_memo_free(body->refinement_memo);
         SIZED_FREE(body);
     }
 
@@ -324,6 +327,7 @@ iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen)
     body->variable.coverage = Qnil;
     body->variable.pc2branchindex = Qnil;
     body->variable.original_iseq = NULL;
+    body->refinement_memo = NULL;
 
     const unsigned int iseq_size = src_body->iseq_size;
     const unsigned int is_size = ISEQ_IS_SIZE(src_body);
@@ -564,6 +568,91 @@ rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq)
     return copy;
 }
 
+/* --- Proc#dup_with_refinements: single-entry per-iseq memo ---
+ *
+ * Copying an iseq (above) is expensive, so the most recent {copied iseq, cref}
+ * pair produced from a given source iseq is memoized on the source iseq's body,
+ * keyed by (base_cref, modules).  Repeatedly calling dup_with_refinements on the
+ * same proc with the same modules then reuses the copy instead of rebuilding it.
+ * Sharing a copy is safe because all results for one key run under the same
+ * refinement set, so their inline caches resolve identically.  The memo is owned
+ * by the source iseq, so its entries live exactly as long as the source iseq. */
+
+struct rb_iseq_refinement_memo {
+    const rb_cref_t *base_cref;     /* key: captured cref of the source proc */
+    long argc;                      /* key: number of modules */
+    VALUE *mods;                    /* key: argc module objects (heap-allocated) */
+    const rb_iseq_t *copied_iseq;   /* value: copied iseq with independent caches */
+    const rb_cref_t *cref;          /* value: cref with refinements activated */
+};
+
+static bool
+iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
+                               const rb_cref_t *base_cref, long argc, const VALUE *mods)
+{
+    if (memo->base_cref != base_cref || memo->argc != argc) return false;
+    for (long i = 0; i < argc; i++) {
+        if (memo->mods[i] != mods[i]) return false;
+    }
+    return true;
+}
+
+/* On a key hit, fill *iseq_out / *cref_out and return true; otherwise false. */
+bool
+rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
+                               long argc, const VALUE *mods,
+                               const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
+{
+    const struct rb_iseq_refinement_memo *memo = ISEQ_BODY(src_iseq)->refinement_memo;
+    if (memo && iseq_refinement_memo_key_match(memo, base_cref, argc, mods)) {
+        *iseq_out = memo->copied_iseq;
+        *cref_out = memo->cref;
+        return true;
+    }
+    return false;
+}
+
+/* Replace the single memo entry with the given key/value (overwriting any
+ * previous entry). */
+void
+rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
+                              long argc, const VALUE *mods,
+                              const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
+{
+    struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
+    struct rb_iseq_refinement_memo *memo = body->refinement_memo;
+    if (memo == NULL) {
+        memo = ZALLOC(struct rb_iseq_refinement_memo);
+        body->refinement_memo = memo;
+    }
+    else {
+        ruby_xfree(memo->mods);
+    }
+    memo->base_cref = base_cref;
+    memo->argc = argc;
+    memo->mods = ALLOC_N(VALUE, argc);
+    MEMCPY(memo->mods, mods, VALUE, argc);
+    memo->copied_iseq = copied_iseq;
+    memo->cref = cref;
+
+    /* src_iseq now references these objects through the memo. */
+    RB_OBJ_WRITTEN(src_iseq, Qundef, copied_iseq);
+    RB_OBJ_WRITTEN(src_iseq, Qundef, (VALUE)cref);
+    if (base_cref) RB_OBJ_WRITTEN(src_iseq, Qundef, (VALUE)base_cref);
+    for (long i = 0; i < argc; i++) {
+        if (!SPECIAL_CONST_P(mods[i])) RB_OBJ_WRITTEN(src_iseq, Qundef, mods[i]);
+    }
+}
+
+static void
+iseq_refinement_memo_free(struct rb_iseq_refinement_memo *memo)
+{
+    if (memo) {
+        ruby_xfree(memo->mods);
+        ruby_xfree(memo);
+    }
+}
+
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);
 
 static inline void
@@ -707,6 +796,16 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
         if (body->parent_iseq) rb_gc_mark_and_move_ptr(&body->parent_iseq);
         if (body->mandatory_only_iseq) rb_gc_mark_and_move_ptr(&body->mandatory_only_iseq);
 
+        if (body->refinement_memo) {
+            struct rb_iseq_refinement_memo *memo = body->refinement_memo;
+            if (memo->base_cref) rb_gc_mark_and_move((VALUE *)&memo->base_cref);
+            if (memo->cref) rb_gc_mark_and_move((VALUE *)&memo->cref);
+            if (memo->copied_iseq) rb_gc_mark_and_move_ptr(&memo->copied_iseq);
+            for (long i = 0; i < memo->argc; i++) {
+                rb_gc_mark_and_move(&memo->mods[i]);
+            }
+        }
+
         if (body->call_data) {
             for (unsigned int i = 0; i < body->ci_size; i++) {
                 struct rb_call_data *cds = body->call_data;
@@ -848,6 +947,11 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         /* body->call_data */
         size += body->ci_size * sizeof(struct rb_call_data);
         // TODO: should we count imemo_callinfo?
+
+        if (body->refinement_memo) {
+            size += sizeof(struct rb_iseq_refinement_memo);
+            size += body->refinement_memo->argc * sizeof(VALUE);
+        }
     }
 
     compile_data = ISEQ_COMPILE_DATA(iseq);

--- a/iseq.c
+++ b/iseq.c
@@ -244,7 +244,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
     RUBY_FREE_LEAVE("iseq");
 }
 
-/* --- Proc#dup_with_refinements: recursive iseq copy with independent caches ---
+/* --- Proc#with_refinements: recursive iseq copy with independent caches ---
  *
  * Produces a structural copy of an iseq (and, recursively, its child iseqs) that
  * shares immutable, lexically-fixed data with the original but has its own
@@ -570,11 +570,11 @@ rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq)
     return copy;
 }
 
-/* --- Proc#dup_with_refinements: single-entry per-iseq memo ---
+/* --- Proc#with_refinements: single-entry per-iseq memo ---
  *
  * Copying an iseq (above) is expensive, so the most recent {copied iseq, cref}
  * pair produced from a given source iseq is memoized on the source iseq's body,
- * keyed by (base_cref, modules).  Repeatedly calling dup_with_refinements on the
+ * keyed by (base_cref, modules).  Repeatedly calling with_refinements on the
  * same proc with the same modules then reuses the copy instead of rebuilding it.
  * Sharing a copy is safe because all results for one key run under the same
  * refinement set, so their inline caches resolve identically.  The memo is owned
@@ -631,7 +631,7 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
 
     struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
     /* The memo shares storage with mandatory_only_iseq, discriminated by the
-     * iseq type; dup_with_refinements sources are always block iseqs. */
+     * iseq type; with_refinements sources are always block iseqs. */
     VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
     struct rb_iseq_refinement_memo *memo = body->opt.refinement_memo;
     if (memo == NULL) {

--- a/iseq.c
+++ b/iseq.c
@@ -319,6 +319,9 @@ iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen)
     body->yjit_payload = NULL;
     body->yjit_calls_at_interv = 0;
 #endif
+#if USE_ZJIT
+    body->zjit_payload = NULL;
+#endif
     body->variable.flip_count = 0;
     body->variable.coverage = Qnil;
     body->variable.pc2branchindex = Qnil;

--- a/iseq.c
+++ b/iseq.c
@@ -239,6 +239,331 @@ rb_iseq_free(const rb_iseq_t *iseq)
     RUBY_FREE_LEAVE("iseq");
 }
 
+/* --- Proc#dup_with_refinements: recursive iseq copy with independent caches ---
+ *
+ * Produces a structural copy of an iseq (and, recursively, its child iseqs) that
+ * shares immutable, lexically-fixed data with the original but has its own
+ * inline method caches (call_data) and inline storage entries (is_entries).
+ * This lets the copy run under a different refinement cref without leaking the
+ * cached refined-method resolutions into the original iseq.  The bytecode and
+ * all literals are identical; only the per-iseq caches are fresh.
+ */
+
+int rb_iseq_translate_threaded_code(rb_iseq_t *iseq); /* compile.c */
+static rb_iseq_t *iseq_alloc(void);
+
+static const ID *
+iseq_dup_idlist(const ID *src)
+{
+    if (src == NULL) return NULL;
+    int n = 0;
+    while (src[n]) n++;
+    ID *dst = ALLOC_N(ID, n + 1);
+    MEMCPY(dst, src, ID, n + 1);
+    return dst;
+}
+
+static enum rb_id_table_iterator_result
+iseq_dup_outer_variable_i(ID id, VALUE val, void *data)
+{
+    rb_id_table_insert((struct rb_id_table *)data, id, val);
+    return ID_TABLE_CONTINUE;
+}
+
+static const rb_iseq_t *iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen);
+
+static const rb_iseq_t *
+iseq_dup_child_for_refinements(const rb_iseq_t *child, st_table *seen)
+{
+    return child ? iseq_dup_for_refinements(child, seen) : NULL;
+}
+
+static const rb_iseq_t *
+iseq_map_to_copy(const rb_iseq_t *iseq, st_table *seen)
+{
+    /* Remap an iseq pointer to its copy if it is inside the copied subtree;
+     * otherwise (e.g. an enclosing method/top iseq) keep the original. */
+    st_data_t v;
+    if (iseq && st_lookup(seen, (st_data_t)iseq, &v)) {
+        return (const rb_iseq_t *)v;
+    }
+    return iseq;
+}
+
+static const rb_iseq_t *
+iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen)
+{
+    st_data_t found;
+    if (st_lookup(seen, (st_data_t)src, &found)) {
+        return (const rb_iseq_t *)found;
+    }
+
+    rb_iseq_t *new_iseq = iseq_alloc();
+    st_insert(seen, (st_data_t)src, (st_data_t)new_iseq);
+
+    const struct rb_iseq_constant_body *const src_body = ISEQ_BODY(src);
+    struct rb_iseq_constant_body *const body = ISEQ_BODY(new_iseq);
+
+    /* Start from a shallow copy: scalars and pointers to immutable, shared data
+     * (location strings, etc.).  Owned arrays are replaced with duplicates
+     * below so that freeing one iseq never frees the other's memory. */
+    *body = *src_body;
+
+    /* mutable / per-iseq state that must not be shared or carried over */
+#if USE_YJIT || USE_ZJIT
+    body->jit_entry = NULL;
+    body->jit_entry_calls = 0;
+    body->jit_exception = NULL;
+    body->jit_exception_calls = 0;
+#endif
+#if USE_YJIT
+    body->yjit_payload = NULL;
+    body->yjit_calls_at_interv = 0;
+#endif
+    body->variable.flip_count = 0;
+    body->variable.coverage = Qnil;
+    body->variable.pc2branchindex = Qnil;
+    body->variable.original_iseq = NULL;
+
+    const unsigned int iseq_size = src_body->iseq_size;
+    const unsigned int is_size = ISEQ_IS_SIZE(src_body);
+    const unsigned int ci_size = src_body->ci_size;
+
+    /* call_data: fresh cache, sharing the (immutable) callinfo entries. */
+    if (ci_size > 0) {
+        struct rb_call_data *cds = ZALLOC_N(struct rb_call_data, ci_size);
+        for (unsigned int i = 0; i < ci_size; i++) {
+            const struct rb_callinfo *ci = src_body->call_data[i].ci;
+            cds[i].ci = ci;
+            if (ci) {
+                RB_OBJ_WRITTEN(new_iseq, Qundef, ci);
+                cds[i].cc = vm_cc_empty();
+            }
+            else {
+                cds[i].cc = NULL;
+            }
+        }
+        body->call_data = cds;
+    }
+    else {
+        body->call_data = NULL;
+    }
+
+    /* is_entries: copy initialized state, then make caches cold and give each
+     * inline constant cache its own constant-path idlist (it is freed per iseq).
+     * The constant cache entry must be reset so the copy re-registers itself in
+     * the global constant cache instead of holding a stale, unregistered one. */
+    if (is_size > 0) {
+        union iseq_inline_storage_entry *is = ALLOC_N(union iseq_inline_storage_entry, is_size);
+        MEMCPY(is, src_body->is_entries, union iseq_inline_storage_entry, is_size);
+        body->is_entries = is;
+        for (unsigned int i = 0; i < src_body->ic_size; i++) {
+            IC ic = &ISEQ_IS_IC_ENTRY(body, i);
+            ic->entry = NULL;
+            ic->segments = iseq_dup_idlist(ic->segments);
+        }
+    }
+    else {
+        body->is_entries = NULL;
+    }
+
+    /* iseq_encoded: copy the untranslated bytecode, rewrite operands that point
+     * at per-iseq data (call_data, is_entries, child iseqs), then translate. */
+    {
+        const VALUE *orig = rb_iseq_original_iseq((rb_iseq_t *)src);
+        VALUE *code = ALLOC_N(VALUE, iseq_size);
+        MEMCPY(code, orig, VALUE, iseq_size);
+        body->iseq_encoded = code;
+
+        iseq_bits_t *mark_bits;
+        unsigned int buflen = ISEQ_MBITS_BUFLEN(iseq_size);
+        if (buflen == 1) {
+            body->mark_bits.single = 0;
+            mark_bits = &body->mark_bits.single;
+        }
+        else {
+            body->mark_bits.list = ZALLOC_N(iseq_bits_t, buflen);
+            mark_bits = body->mark_bits.list;
+        }
+
+        for (unsigned int i = 0; i < iseq_size; ) {
+            int insn = (int)code[i];
+            const char *types = insn_op_types(insn);
+            int len = insn_len(insn);
+
+            for (int j = 0; types[j]; j++) {
+                unsigned int pos = i + 1 + j;
+                switch (types[j]) {
+                  case TS_CALLDATA: {
+                    const struct rb_call_data *old_cd = (const struct rb_call_data *)code[pos];
+                    code[pos] = (VALUE)(body->call_data + (old_cd - src_body->call_data));
+                    break;
+                  }
+                  case TS_IC:
+                  case TS_ISE:
+                  case TS_IVC:
+                  case TS_ICVARC: {
+                    const union iseq_inline_storage_entry *old =
+                        (const union iseq_inline_storage_entry *)code[pos];
+                    code[pos] = (VALUE)(body->is_entries + (old - src_body->is_entries));
+                    break;
+                  }
+                  case TS_ISEQ: {
+                    const rb_iseq_t *child = (const rb_iseq_t *)code[pos];
+                    if (child) {
+                        const rb_iseq_t *newchild = iseq_dup_for_refinements(child, seen);
+                        code[pos] = (VALUE)newchild;
+                        RB_OBJ_WRITTEN(new_iseq, Qundef, newchild);
+                        ISEQ_MBITS_SET(mark_bits, pos);
+                    }
+                    break;
+                  }
+                  case TS_VALUE:
+                  case TS_CDHASH: {
+                    VALUE v = code[pos];
+                    if (!SPECIAL_CONST_P(v)) {
+                        RB_OBJ_WRITTEN(new_iseq, Qundef, v);
+                        ISEQ_MBITS_SET(mark_bits, pos);
+                    }
+                    break;
+                  }
+                  default:
+                    break;
+                }
+            }
+            i += len;
+        }
+    }
+
+    /* insns_info (line/event table). */
+    if (src_body->insns_info.size > 0 && src_body->insns_info.body) {
+        unsigned int n = src_body->insns_info.size;
+        struct iseq_insn_info_entry *ib = ALLOC_N(struct iseq_insn_info_entry, n);
+        MEMCPY(ib, src_body->insns_info.body, struct iseq_insn_info_entry, n);
+        body->insns_info.body = ib;
+    }
+#if VM_INSN_INFO_TABLE_IMPL == 2
+    body->insns_info.succ_index_table = NULL;
+    if (src_body->insns_info.positions) {
+        unsigned int n = src_body->insns_info.size;
+        unsigned int *positions = ALLOC_N(unsigned int, n);
+        MEMCPY(positions, src_body->insns_info.positions, unsigned int, n);
+        body->insns_info.positions = positions;
+    }
+    else {
+        body->insns_info.positions = rb_iseq_insns_info_decode_positions(src_body);
+    }
+    rb_iseq_insns_info_encode_positions(new_iseq);
+#else
+    if (src_body->insns_info.positions && src_body->insns_info.size > 0) {
+        unsigned int n = src_body->insns_info.size;
+        unsigned int *positions = ALLOC_N(unsigned int, n);
+        MEMCPY(positions, src_body->insns_info.positions, unsigned int, n);
+        body->insns_info.positions = positions;
+    }
+#endif
+
+    /* catch table, with its child iseqs replaced by copies. */
+    if (src_body->catch_table) {
+        unsigned int size = src_body->catch_table->size;
+        size_t bytes = iseq_catch_table_bytes(size);
+        struct iseq_catch_table *ct = ruby_xmalloc(bytes);
+        memcpy(ct, src_body->catch_table, bytes);
+        for (unsigned int i = 0; i < size; i++) {
+            struct iseq_catch_table_entry *entry =
+                UNALIGNED_MEMBER_PTR(ct, entries[i]);
+            if (entry->iseq) {
+                entry->iseq = (rb_iseq_t *)iseq_dup_for_refinements(entry->iseq, seen);
+                RB_OBJ_WRITTEN(new_iseq, Qundef, entry->iseq);
+            }
+        }
+        body->catch_table = ct;
+    }
+
+    /* local variable tables. */
+    if (src_body->local_table && src_body->local_table != rb_iseq_shared_exc_local_tbl) {
+        ID *lt = ALLOC_N(ID, src_body->local_table_size);
+        MEMCPY(lt, src_body->local_table, ID, src_body->local_table_size);
+        body->local_table = lt;
+    }
+    if (src_body->lvar_states) {
+        enum lvar_state *ls = ALLOC_N(enum lvar_state, src_body->local_table_size);
+        MEMCPY(ls, src_body->lvar_states, enum lvar_state, src_body->local_table_size);
+        body->lvar_states = ls;
+    }
+
+    /* parameter tables. */
+    if (src_body->param.opt_table) {
+        VALUE *ot = ALLOC_N(VALUE, src_body->param.opt_num + 1);
+        MEMCPY(ot, src_body->param.opt_table, VALUE, src_body->param.opt_num + 1);
+        body->param.opt_table = ot;
+    }
+    if (src_body->param.keyword) {
+        const struct rb_iseq_param_keyword *sk = src_body->param.keyword;
+        struct rb_iseq_param_keyword *kw = ALLOC(struct rb_iseq_param_keyword);
+        *kw = *sk;
+        if (sk->table == &src_body->local_table[sk->bits_start - sk->num]) {
+            /* table aliases the (now duplicated) local table */
+            kw->table = &body->local_table[kw->bits_start - kw->num];
+        }
+        else {
+            ID *t = ALLOC_N(ID, sk->required_num);
+            MEMCPY(t, sk->table, ID, sk->required_num);
+            kw->table = t;
+        }
+        if (sk->default_values) {
+            int dv_num = sk->num - sk->required_num;
+            VALUE *dvs = ALLOC_N(VALUE, dv_num);
+            MEMCPY(dvs, sk->default_values, VALUE, dv_num);
+            for (int i = 0; i < dv_num; i++) {
+                if (!SPECIAL_CONST_P(dvs[i])) RB_OBJ_WRITTEN(new_iseq, Qundef, dvs[i]);
+            }
+            kw->default_values = dvs;
+        }
+        body->param.keyword = kw;
+    }
+
+    /* outer variable table. */
+    if (src_body->outer_variables) {
+        struct rb_id_table *ovs = rb_id_table_create(rb_id_table_size(src_body->outer_variables));
+        rb_id_table_foreach(src_body->outer_variables, iseq_dup_outer_variable_i, ovs);
+        body->outer_variables = ovs;
+    }
+
+    /* iseq cross references: remap into the copied subtree where applicable. */
+    body->parent_iseq = iseq_map_to_copy(src_body->parent_iseq, seen);
+    if (body->parent_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->parent_iseq);
+    body->local_iseq = (rb_iseq_t *)iseq_map_to_copy(src_body->local_iseq, seen);
+    if (body->local_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->local_iseq);
+    body->mandatory_only_iseq = iseq_dup_child_for_refinements(src_body->mandatory_only_iseq, seen);
+    if (body->mandatory_only_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->mandatory_only_iseq);
+
+    /* shared VALUE references that need write barriers on the new iseq. */
+    RB_OBJ_WRITTEN(new_iseq, Qundef, body->location.pathobj);
+    RB_OBJ_WRITTEN(new_iseq, Qundef, body->location.base_label);
+    RB_OBJ_WRITTEN(new_iseq, Qundef, body->location.label);
+    if (!SPECIAL_CONST_P(body->variable.script_lines)) {
+        RB_OBJ_WRITTEN(new_iseq, Qundef, body->variable.script_lines);
+    }
+
+    /* Translate to threaded code first, then instrument for tracing, matching
+     * the order in finish_iseq_build (rb_iseq_trace_set rewrites translated
+     * instructions). */
+    rb_iseq_translate_threaded_code(new_iseq);
+    rb_iseq_init_trace(new_iseq);
+
+    return new_iseq;
+}
+
+const rb_iseq_t *
+rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq)
+{
+    st_table *seen = st_init_numtable();
+    const rb_iseq_t *copy = iseq_dup_for_refinements(iseq, seen);
+    st_free_table(seen);
+    return copy;
+}
+
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);
 
 static inline void

--- a/iseq.c
+++ b/iseq.c
@@ -235,7 +235,9 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
         compile_data_free(ISEQ_COMPILE_DATA(iseq));
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
-        iseq_refinement_memo_free(body->refinement_memo);
+        /* refinement_memo shares a slot with mandatory_only_iseq (a GC object,
+         * not owned here); only block iseqs hold a memo to free. */
+        if (body->type == ISEQ_TYPE_BLOCK) iseq_refinement_memo_free(body->refinement_memo);
         SIZED_FREE(body);
     }
 
@@ -274,12 +276,6 @@ iseq_dup_outer_variable_i(ID id, VALUE val, void *data)
 }
 
 static const rb_iseq_t *iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen);
-
-static const rb_iseq_t *
-iseq_dup_child_for_refinements(const rb_iseq_t *child, st_table *seen)
-{
-    return child ? iseq_dup_for_refinements(child, seen) : NULL;
-}
 
 static const rb_iseq_t *
 iseq_map_to_copy(const rb_iseq_t *iseq, st_table *seen)
@@ -539,8 +535,11 @@ iseq_dup_for_refinements(const rb_iseq_t *src, st_table *seen)
     if (body->parent_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->parent_iseq);
     body->local_iseq = (rb_iseq_t *)iseq_map_to_copy(src_body->local_iseq, seen);
     if (body->local_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->local_iseq);
-    body->mandatory_only_iseq = iseq_dup_child_for_refinements(src_body->mandatory_only_iseq, seen);
-    if (body->mandatory_only_iseq) RB_OBJ_WRITTEN(new_iseq, Qundef, body->mandatory_only_iseq);
+    /* The mandatory_only_iseq slot is shared (union) with refinement_memo.
+     * Every iseq copied here belongs to a block's subtree (blocks and their
+     * rescue/ensure iseqs), none of which has a mandatory-only variant, so the
+     * slot is always NULL in this context; refinement_memo is reset to NULL
+     * above and the copy must not carry the source's memo. */
 
     /* shared VALUE references that need write barriers on the new iseq. */
     RB_OBJ_WRITTEN(new_iseq, Qundef, body->location.pathobj);
@@ -628,6 +627,9 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
     MEMCPY(new_mods, mods, VALUE, argc);
 
     struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
+    /* The memo shares storage with mandatory_only_iseq, discriminated by the
+     * iseq type; dup_with_refinements sources are always block iseqs. */
+    VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
     struct rb_iseq_refinement_memo *memo = body->refinement_memo;
     if (memo == NULL) {
         /* Zeroed (argc == 0, mods == NULL), so it is safe to mark before it is
@@ -805,16 +807,22 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
         rb_gc_mark_and_move(&body->location.pathobj);
         if (body->local_iseq) rb_gc_mark_and_move_ptr(&body->local_iseq);
         if (body->parent_iseq) rb_gc_mark_and_move_ptr(&body->parent_iseq);
-        if (body->mandatory_only_iseq) rb_gc_mark_and_move_ptr(&body->mandatory_only_iseq);
 
-        if (body->refinement_memo) {
-            struct rb_iseq_refinement_memo *memo = body->refinement_memo;
-            if (memo->base_cref) rb_gc_mark_and_move((VALUE *)&memo->base_cref);
-            if (memo->cref) rb_gc_mark_and_move((VALUE *)&memo->cref);
-            if (memo->copied_iseq) rb_gc_mark_and_move_ptr(&memo->copied_iseq);
-            for (long i = 0; i < memo->argc; i++) {
-                rb_gc_mark_and_move(&memo->mods[i]);
+        /* mandatory_only_iseq and refinement_memo share a slot (see vm_core.h);
+         * the iseq type selects which one is live. */
+        if (body->type == ISEQ_TYPE_BLOCK) {
+            if (body->refinement_memo) {
+                struct rb_iseq_refinement_memo *memo = body->refinement_memo;
+                if (memo->base_cref) rb_gc_mark_and_move((VALUE *)&memo->base_cref);
+                if (memo->cref) rb_gc_mark_and_move((VALUE *)&memo->cref);
+                if (memo->copied_iseq) rb_gc_mark_and_move_ptr(&memo->copied_iseq);
+                for (long i = 0; i < memo->argc; i++) {
+                    rb_gc_mark_and_move(&memo->mods[i]);
+                }
             }
+        }
+        else if (body->mandatory_only_iseq) {
+            rb_gc_mark_and_move_ptr(&body->mandatory_only_iseq);
         }
 
         if (body->call_data) {
@@ -959,7 +967,9 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += body->ci_size * sizeof(struct rb_call_data);
         // TODO: should we count imemo_callinfo?
 
-        if (body->refinement_memo) {
+        /* refinement_memo shares a slot with mandatory_only_iseq; only block
+         * iseqs hold a memo. */
+        if (body->type == ISEQ_TYPE_BLOCK && body->refinement_memo) {
             size += sizeof(struct rb_iseq_refinement_memo);
             size += body->refinement_memo->argc * sizeof(VALUE);
         }

--- a/jit.c
+++ b/jit.c
@@ -227,7 +227,8 @@ rb_optimized_call(VALUE recv, rb_execution_context_t *ec, int argc, VALUE *argv,
 {
     rb_proc_t *proc;
     GetProcPtr(recv, proc);
-    return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler);
+    return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler,
+                             proc->has_refinements ? rb_proc_refinements_cref(recv) : NULL);
 }
 
 unsigned int

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3646,7 +3646,7 @@ pm_compile_builtin_mandatory_only_method(rb_iseq_t *iseq, pm_scope_node_t *scope
         ISEQ_TYPE_METHOD,
         ISEQ_COMPILE_DATA(iseq)->option
     );
-    RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->mandatory_only_iseq, (VALUE)mandatory_only_iseq);
+    RB_OBJ_WRITE(iseq, &ISEQ_BODY(iseq)->opt.mandatory_only_iseq, (VALUE)mandatory_only_iseq);
 
     pm_scope_node_destroy(&next_scope_node);
     return COMPILE_OK;

--- a/proc.c
+++ b/proc.c
@@ -82,6 +82,9 @@ proc_mark_and_move(void *ptr)
 {
     rb_proc_t *proc = ptr;
     block_mark_and_move((struct rb_block *)&proc->block);
+    if (proc->cref) {
+        rb_gc_mark_and_move((VALUE *)&proc->cref);
+    }
 }
 
 typedef struct {
@@ -138,6 +141,78 @@ proc_dup(VALUE self)
 {
     VALUE procval = rb_proc_dup(self);
     return rb_obj_dup_setup(self, procval);
+}
+
+rb_cref_t *rb_vm_get_cref(const VALUE *ep);
+VALUE rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref);
+const rb_iseq_t *rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq);
+
+/*
+ * call-seq:
+ *   prc.dup_with_refinements(mod, ...) -> a_proc
+ *
+ * Returns a new Proc that behaves like the receiver but with the refinements
+ * activated by the given modules in effect inside its body.  The receiver is
+ * left unchanged.
+ *
+ * The block's instruction sequences are copied recursively so that the new
+ * Proc resolves methods independently of the original.  Because this copy is
+ * relatively expensive, callers that invoke the result repeatedly should cache
+ * it.
+ *
+ *   module StringRefinement
+ *     refine String do
+ *       def shout = upcase + "!"
+ *     end
+ *   end
+ *
+ *   original = ->(s) { s.shout }
+ *   refined = original.dup_with_refinements(StringRefinement)
+ *   refined.call("hi")     #=> "HI!"
+ *   original.call("hi")    #=> NoMethodError
+ *
+ * Only Procs created from a Ruby block (an instruction sequence) are
+ * supported; calling this on a Proc backed by a C function, a Symbol, or a
+ * method raises ArgumentError.
+ */
+static VALUE
+proc_dup_with_refinements(int argc, VALUE *argv, VALUE self)
+{
+    rb_proc_t *src;
+    GetProcPtr(self, src);
+
+    rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+
+    if (vm_block_type(&src->block) != block_type_iseq) {
+        rb_raise(rb_eArgError, "can't apply refinements to a Proc without an iseq block");
+    }
+    if (src->is_from_method) {
+        /* Procs created from methods are invoked through the bmethod path, which
+         * resolves methods against the method entry rather than the proc's cref,
+         * so the refinements would silently not take effect. */
+        rb_raise(rb_eArgError, "can't apply refinements to a Proc created from a method");
+    }
+
+    for (int i = 0; i < argc; i++) {
+        Check_Type(argv[i], T_MODULE);
+    }
+
+    /* Duplicate the block's cref (keeping its current refinements) and activate
+     * the refinements of each module argument on the copy. */
+    const rb_cref_t *base_cref = rb_vm_get_cref(src->block.as.captured.ep);
+    rb_cref_t *new_cref = rb_vm_cref_dup(base_cref);
+    for (int i = 0; i < argc; i++) {
+        rb_using_module(new_cref, argv[i]);
+    }
+
+    /* Recursively copy the block's iseq (and its children) so the new Proc has
+     * its own inline method caches.  This is required for correctness: the VM
+     * caches refinement method resolution per call site assuming one iseq runs
+     * under a single lexical cref, so sharing the iseq would leak the refined
+     * methods into the original Proc. */
+    const rb_iseq_t *new_iseq = rb_iseq_dup_with_independent_caches(src->block.as.captured.code.iseq);
+
+    return rb_proc_dup_with_iseq_and_cref(self, new_iseq, new_cref);
 }
 
 /*
@@ -4658,6 +4733,7 @@ Init_Proc(void)
     rb_define_method(rb_cProc, "arity", proc_arity, 0);
     rb_define_method(rb_cProc, "clone", proc_clone, 0);
     rb_define_method(rb_cProc, "dup", proc_dup, 0);
+    rb_define_method(rb_cProc, "dup_with_refinements", proc_dup_with_refinements, -1);
     rb_define_method(rb_cProc, "hash", proc_hash, 0);
     rb_define_method(rb_cProc, "to_s", proc_to_s, 0);
     rb_define_alias(rb_cProc, "inspect", "to_s");

--- a/proc.c
+++ b/proc.c
@@ -198,11 +198,14 @@ proc_dup_with_refinements(int argc, VALUE *argv, VALUE self)
     }
 
     /* Duplicate the block's cref (keeping its current refinements) and activate
-     * the refinements of each module argument on the copy. */
+     * the refinements of each module argument on the copy.  The cref is freshly
+     * duplicated and not referenced by any call site yet, so we use
+     * rb_using_module_recursive directly and skip the global refinement method
+     * cache flush that the top-level `using` (rb_using_module) performs. */
     const rb_cref_t *base_cref = rb_vm_get_cref(src->block.as.captured.ep);
     rb_cref_t *new_cref = rb_vm_cref_dup(base_cref);
     for (int i = 0; i < argc; i++) {
-        rb_using_module(new_cref, argv[i]);
+        rb_using_module_recursive(new_cref, argv[i]);
     }
 
     /* Recursively copy the block's iseq (and its children) so the new Proc has

--- a/proc.c
+++ b/proc.c
@@ -19,6 +19,7 @@
 #include "internal/object.h"
 #include "internal/proc.h"
 #include "internal/symbol.h"
+#include "internal/vm.h"
 #include "method.h"
 #include "iseq.h"
 #include "vm_core.h"

--- a/proc.c
+++ b/proc.c
@@ -147,6 +147,12 @@ proc_dup(VALUE self)
 rb_cref_t *rb_vm_get_cref(const VALUE *ep);
 VALUE rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref);
 const rb_iseq_t *rb_iseq_dup_with_independent_caches(const rb_iseq_t *iseq);
+bool rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
+                                    long argc, const VALUE *mods,
+                                    const rb_iseq_t **iseq_out, const rb_cref_t **cref_out);
+void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
+                                   long argc, const VALUE *mods,
+                                   const rb_iseq_t *copied_iseq, const rb_cref_t *cref);
 
 /*
  * call-seq:
@@ -198,23 +204,38 @@ proc_dup_with_refinements(int argc, VALUE *argv, VALUE self)
         Check_Type(argv[i], T_MODULE);
     }
 
-    /* Duplicate the block's cref (keeping its current refinements) and activate
-     * the refinements of each module argument on the copy.  The cref is freshly
-     * duplicated and not referenced by any call site yet, so we use
-     * rb_using_module_recursive directly and skip the global refinement method
-     * cache flush that the top-level `using` (rb_using_module) performs. */
     const rb_cref_t *base_cref = rb_vm_get_cref(src->block.as.captured.ep);
-    rb_cref_t *new_cref = rb_vm_cref_dup(base_cref);
-    for (int i = 0; i < argc; i++) {
-        rb_using_module_recursive(new_cref, argv[i]);
-    }
+    const rb_iseq_t *src_iseq = src->block.as.captured.code.iseq;
 
-    /* Recursively copy the block's iseq (and its children) so the new Proc has
-     * its own inline method caches.  This is required for correctness: the VM
-     * caches refinement method resolution per call site assuming one iseq runs
-     * under a single lexical cref, so sharing the iseq would leak the refined
-     * methods into the original Proc. */
-    const rb_iseq_t *new_iseq = rb_iseq_dup_with_independent_caches(src->block.as.captured.code.iseq);
+    /* Reuse the most recent {copied iseq, cref} pair if this same iseq was
+     * already given the same (base_cref, modules).  Copying the iseq is
+     * expensive, and all results for one key run under the same refinement set,
+     * so sharing the copy and its warmed caches is safe.  See the memo helpers
+     * in iseq.c. */
+    const rb_iseq_t *new_iseq;
+    const rb_cref_t *new_cref;
+    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
+        /* Duplicate the block's cref (keeping its current refinements) and
+         * activate the refinements of each module argument on the copy.  The
+         * cref is freshly duplicated and not referenced by any call site yet, so
+         * we use rb_using_module_recursive directly and skip the global
+         * refinement method cache flush that the top-level `using`
+         * (rb_using_module) performs. */
+        rb_cref_t *cref = rb_vm_cref_dup(base_cref);
+        for (int i = 0; i < argc; i++) {
+            rb_using_module_recursive(cref, argv[i]);
+        }
+
+        /* Recursively copy the block's iseq (and its children) so the new Proc
+         * has its own inline method caches.  This is required for correctness:
+         * the VM caches refinement method resolution per call site assuming one
+         * iseq runs under a single lexical cref, so sharing the iseq would leak
+         * the refined methods into the original Proc. */
+        new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
+        new_cref = cref;
+
+        rb_iseq_refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
+    }
 
     return rb_proc_dup_with_iseq_and_cref(self, new_iseq, new_cref);
 }

--- a/proc.c
+++ b/proc.c
@@ -79,7 +79,7 @@ block_mark_and_move(struct rb_block *block)
 }
 
 /* Hidden (Ruby-invisible) instance-variable id holding a refinement proc's
- * cref; see Proc#dup_with_refinements. */
+ * cref; see Proc#with_refinements. */
 static ID id_refinements_cref;
 
 static void
@@ -172,7 +172,7 @@ void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *b
 
 /*
  * call-seq:
- *   prc.dup_with_refinements(mod, ...) -> a_proc
+ *   prc.with_refinements(mod, ...) -> a_proc
  *
  * Returns a new Proc that behaves like the receiver but with the refinements
  * activated by the given modules in effect inside its body.  The receiver is
@@ -185,7 +185,7 @@ void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *b
  *   end
  *
  *   original = ->(s) { s.shout }
- *   refined = original.dup_with_refinements(StringRefinement)
+ *   refined = original.with_refinements(StringRefinement)
  *   refined.call("hi")     #=> "HI!"
  *   original.call("hi")    #=> NoMethodError
  *
@@ -193,7 +193,7 @@ void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *b
  * backed by a C function, a Symbol, or a method raises ArgumentError.
  */
 static VALUE
-proc_dup_with_refinements(int argc, VALUE *argv, VALUE self)
+proc_with_refinements(int argc, VALUE *argv, VALUE self)
 {
     rb_proc_t *src;
     GetProcPtr(self, src);
@@ -4771,7 +4771,7 @@ Init_Proc(void)
     rb_define_method(rb_cProc, "arity", proc_arity, 0);
     rb_define_method(rb_cProc, "clone", proc_clone, 0);
     rb_define_method(rb_cProc, "dup", proc_dup, 0);
-    rb_define_method(rb_cProc, "dup_with_refinements", proc_dup_with_refinements, -1);
+    rb_define_method(rb_cProc, "with_refinements", proc_with_refinements, -1);
     rb_define_method(rb_cProc, "hash", proc_hash, 0);
     rb_define_method(rb_cProc, "to_s", proc_to_s, 0);
     rb_define_alias(rb_cProc, "inspect", "to_s");

--- a/proc.c
+++ b/proc.c
@@ -78,14 +78,30 @@ block_mark_and_move(struct rb_block *block)
     }
 }
 
+/* Hidden (Ruby-invisible) instance-variable id holding a refinement proc's
+ * cref; see Proc#dup_with_refinements. */
+static ID id_refinements_cref;
+
 static void
 proc_mark_and_move(void *ptr)
 {
     rb_proc_t *proc = ptr;
     block_mark_and_move((struct rb_block *)&proc->block);
-    if (proc->cref) {
-        rb_gc_mark_and_move((VALUE *)&proc->cref);
-    }
+}
+
+const rb_cref_t *
+rb_proc_refinements_cref(VALUE procval)
+{
+    return (const rb_cref_t *)rb_ivar_get(procval, id_refinements_cref);
+}
+
+void
+rb_proc_set_refinements_cref(VALUE procval, const rb_cref_t *cref)
+{
+    rb_proc_t *proc;
+    GetProcPtr(procval, proc);
+    proc->has_refinements = 1;
+    rb_ivar_set(procval, id_refinements_cref, (VALUE)cref);
 }
 
 typedef struct {
@@ -1252,7 +1268,8 @@ rb_proc_call_kw(VALUE self, VALUE args, int kw_splat)
     VALUE *argv = RARRAY_PTR(args);
     GetProcPtr(self, proc);
     vret = rb_vm_invoke_proc(GET_EC(), proc, argc, argv,
-                             kw_splat, VM_BLOCK_HANDLER_NONE);
+                             kw_splat, VM_BLOCK_HANDLER_NONE,
+                             proc->has_refinements ? rb_proc_refinements_cref(self) : NULL);
     RB_GC_GUARD(self);
     RB_GC_GUARD(args);
     return vret;
@@ -1277,7 +1294,8 @@ rb_proc_call_with_block_kw(VALUE self, int argc, const VALUE *argv, VALUE passed
     VALUE vret;
     rb_proc_t *proc;
     GetProcPtr(self, proc);
-    vret = rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, proc_to_block_handler(passed_procval));
+    vret = rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, proc_to_block_handler(passed_procval),
+                             proc->has_refinements ? rb_proc_refinements_cref(self) : NULL);
     RB_GC_GUARD(self);
     return vret;
 }
@@ -4737,6 +4755,7 @@ void
 Init_Proc(void)
 {
 #undef rb_intern
+    id_refinements_cref = rb_make_internal_id();
     /* Proc */
     rb_cProc = rb_define_class("Proc", rb_cObject);
     rb_undef_alloc_func(rb_cProc);

--- a/proc.c
+++ b/proc.c
@@ -178,11 +178,6 @@ void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *b
  * activated by the given modules in effect inside its body.  The receiver is
  * left unchanged.
  *
- * The block's instruction sequences are copied recursively so that the new
- * Proc resolves methods independently of the original.  Because this copy is
- * relatively expensive, callers that invoke the result repeatedly should cache
- * it.
- *
  *   module StringRefinement
  *     refine String do
  *       def shout = upcase + "!"
@@ -194,9 +189,8 @@ void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *b
  *   refined.call("hi")     #=> "HI!"
  *   original.call("hi")    #=> NoMethodError
  *
- * Only Procs created from a Ruby block (an instruction sequence) are
- * supported; calling this on a Proc backed by a C function, a Symbol, or a
- * method raises ArgumentError.
+ * Only Procs created from a Ruby block are supported; calling this on a Proc
+ * backed by a C function, a Symbol, or a method raises ArgumentError.
  */
 static VALUE
 proc_dup_with_refinements(int argc, VALUE *argv, VALUE self)

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -481,6 +481,98 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
+  module DupWithRefinementsModule
+    refine String do
+      def shout = upcase + "!"
+    end
+    refine Integer do
+      def tripled = self * 3
+    end
+  end
+
+  def test_dup_with_refinements
+    orig = ->(s) { s.shout }
+    refined = orig.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal("HI!", refined.call("hi"))
+    # the original Proc is unaffected
+    assert_raise(NoMethodError) { orig.call("hi") }
+    # idempotent: calling repeatedly keeps using the refinement
+    assert_equal("HI!", refined.call("hi"))
+  end
+
+  def test_dup_with_refinements_nested_block
+    orig = ->(a) { a.map { |s| s.shout } }
+    refined = orig.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal(["A!", "B!"], refined.call(["a", "b"]))
+    assert_raise(NoMethodError) { orig.call(["a"]) }
+  end
+
+  def test_dup_with_refinements_multiple_modules
+    refined = ->(s, n) { "#{s.shout}#{n.tripled}" }.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal("A!6", refined.call("a", 2))
+  end
+
+  def test_dup_with_refinements_shares_environment
+    counter = 0
+    inc = -> { counter += 1 }
+    refined = inc.dup_with_refinements(DupWithRefinementsModule)
+    refined.call
+    inc.call
+    # the closure environment is shared with the original Proc
+    assert_equal(2, counter)
+  end
+
+  def test_dup_with_refinements_via_yield
+    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+    result = [].tap {|a| [1, 2].each {|i| a << refined.call("x#{i}") } }
+    assert_equal(["X1!", "X2!"], result)
+
+    forwarded = []
+    rr = ->(s) { forwarded << s.shout }.dup_with_refinements(DupWithRefinementsModule)
+    %w[p q].each(&rr)
+    assert_equal(["P!", "Q!"], forwarded)
+  end
+
+  def test_dup_with_refinements_instance_eval
+    refined = proc { self.shout }.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal("HI!", "hi".instance_eval(&refined))
+    assert_equal("HI!", "hi".instance_exec(&refined))
+    # the original Proc is still unaffected via instance_eval
+    orig = proc { self.shout }
+    assert_raise(NoMethodError) { "hi".instance_eval(&orig) }
+  end
+
+  def test_dup_with_refinements_module_eval
+    refined = proc { "ok".shout }.dup_with_refinements(DupWithRefinementsModule)
+    klass = Class.new
+    assert_equal("OK!", klass.class_eval(&refined))
+  end
+
+  def test_dup_with_refinements_preserved_by_dup
+    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal("Z!", refined.dup.call("z"))
+  end
+
+  def test_dup_with_refinements_errors
+    assert_raise(ArgumentError) { ->(s) { s }.dup_with_refinements }
+    assert_raise(TypeError) { ->(s) { s }.dup_with_refinements(42) }
+    # non-iseq Procs are not supported
+    assert_raise(ArgumentError) { :upcase.to_proc.dup_with_refinements(DupWithRefinementsModule) }
+    assert_raise(ArgumentError) { method(:p).to_proc.dup_with_refinements(DupWithRefinementsModule) }
+  end
+
+  def test_dup_with_refinements_gc
+    assert_normal_exit(<<~RUBY)
+      module M
+        refine(String) { def shout = upcase + "!" }
+      end
+      procs = 100.times.map { |i| ->(s) { s.shout } .dup_with_refinements(M) }
+      GC.start
+      GC.compact rescue nil
+      procs.each { |pr| raise "bad" unless pr.call("a") == "A!" }
+    RUBY
+  end
+
   def test_clone_subclass
     c1 = Class.new(Proc)
     assert_equal c1, c1.new{}.clone.class, '[Bug #17545]'

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -481,7 +481,7 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
-  module DupWithRefinementsModule
+  module WithRefinementsModule
     refine String do
       def shout = upcase + "!"
     end
@@ -490,9 +490,9 @@ class TestProc < Test::Unit::TestCase
     end
   end
 
-  def test_dup_with_refinements
+  def test_with_refinements
     orig = ->(s) { s.shout }
-    refined = orig.dup_with_refinements(DupWithRefinementsModule)
+    refined = orig.with_refinements(WithRefinementsModule)
     assert_equal("HI!", refined.call("hi"))
     # the original Proc is unaffected
     assert_raise(NoMethodError) { orig.call("hi") }
@@ -500,41 +500,41 @@ class TestProc < Test::Unit::TestCase
     assert_equal("HI!", refined.call("hi"))
   end
 
-  def test_dup_with_refinements_nested_block
+  def test_with_refinements_nested_block
     orig = ->(a) { a.map { |s| s.shout } }
-    refined = orig.dup_with_refinements(DupWithRefinementsModule)
+    refined = orig.with_refinements(WithRefinementsModule)
     assert_equal(["A!", "B!"], refined.call(["a", "b"]))
     assert_raise(NoMethodError) { orig.call(["a"]) }
   end
 
-  def test_dup_with_refinements_multiple_modules
-    refined = ->(s, n) { "#{s.shout}#{n.tripled}" }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_multiple_modules
+    refined = ->(s, n) { "#{s.shout}#{n.tripled}" }.with_refinements(WithRefinementsModule)
     assert_equal("A!6", refined.call("a", 2))
   end
 
-  def test_dup_with_refinements_shares_environment
+  def test_with_refinements_shares_environment
     counter = 0
     inc = -> { counter += 1 }
-    refined = inc.dup_with_refinements(DupWithRefinementsModule)
+    refined = inc.with_refinements(WithRefinementsModule)
     refined.call
     inc.call
     # the closure environment is shared with the original Proc
     assert_equal(2, counter)
   end
 
-  def test_dup_with_refinements_via_yield
-    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_via_yield
+    refined = ->(s) { s.shout }.with_refinements(WithRefinementsModule)
     result = [].tap {|a| [1, 2].each {|i| a << refined.call("x#{i}") } }
     assert_equal(["X1!", "X2!"], result)
 
     forwarded = []
-    rr = ->(s) { forwarded << s.shout }.dup_with_refinements(DupWithRefinementsModule)
+    rr = ->(s) { forwarded << s.shout }.with_refinements(WithRefinementsModule)
     %w[p q].each(&rr)
     assert_equal(["P!", "Q!"], forwarded)
   end
 
-  def test_dup_with_refinements_via_c_call_paths
-    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_via_c_call_paths
+    refined = ->(s) { s.shout }.with_refinements(WithRefinementsModule)
     # These reach the proc via the C invocation path (rb_vm_invoke_proc) rather
     # than the optimized opt_call, so the refinement cref must be carried there.
     assert_equal("A!", refined.send(:call, "a"))
@@ -543,8 +543,8 @@ class TestProc < Test::Unit::TestCase
     assert_equal("D!", Thread.new("d", &refined).value)
   end
 
-  def test_dup_with_refinements_instance_eval
-    refined = proc { self.shout }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_instance_eval
+    refined = proc { self.shout }.with_refinements(WithRefinementsModule)
     assert_equal("HI!", "hi".instance_eval(&refined))
     assert_equal("HI!", "hi".instance_exec(&refined))
     # the original Proc is still unaffected via instance_eval
@@ -552,38 +552,38 @@ class TestProc < Test::Unit::TestCase
     assert_raise(NoMethodError) { "hi".instance_eval(&orig) }
   end
 
-  def test_dup_with_refinements_module_eval
-    refined = proc { "ok".shout }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_module_eval
+    refined = proc { "ok".shout }.with_refinements(WithRefinementsModule)
     klass = Class.new
     assert_equal("OK!", klass.class_eval(&refined))
   end
 
-  def test_dup_with_refinements_preserved_by_dup
-    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+  def test_with_refinements_preserved_by_dup
+    refined = ->(s) { s.shout }.with_refinements(WithRefinementsModule)
     assert_equal("Z!", refined.dup.call("z"))
   end
 
-  def test_dup_with_refinements_errors
-    assert_raise(ArgumentError) { ->(s) { s }.dup_with_refinements }
-    assert_raise(TypeError) { ->(s) { s }.dup_with_refinements(42) }
+  def test_with_refinements_errors
+    assert_raise(ArgumentError) { ->(s) { s }.with_refinements }
+    assert_raise(TypeError) { ->(s) { s }.with_refinements(42) }
     # non-iseq Procs are not supported
-    assert_raise(ArgumentError) { :upcase.to_proc.dup_with_refinements(DupWithRefinementsModule) }
-    assert_raise(ArgumentError) { method(:p).to_proc.dup_with_refinements(DupWithRefinementsModule) }
+    assert_raise(ArgumentError) { :upcase.to_proc.with_refinements(WithRefinementsModule) }
+    assert_raise(ArgumentError) { method(:p).to_proc.with_refinements(WithRefinementsModule) }
   end
 
-  def test_dup_with_refinements_gc
+  def test_with_refinements_gc
     assert_normal_exit(<<~RUBY)
       module M
         refine(String) { def shout = upcase + "!" }
       end
-      procs = 100.times.map { |i| ->(s) { s.shout } .dup_with_refinements(M) }
+      procs = 100.times.map { |i| ->(s) { s.shout } .with_refinements(M) }
       GC.start
       GC.compact rescue nil
       procs.each { |pr| raise "bad" unless pr.call("a") == "A!" }
     RUBY
   end
 
-  def test_dup_with_refinements_gc_stress
+  def test_with_refinements_gc_stress
     # Under GC.stress, the memo store allocates its module array while the memo
     # is reachable from the iseq; a GC during that allocation must not observe a
     # half-initialized memo (argc set but mods not yet allocated).  Alternating
@@ -595,13 +595,13 @@ class TestProc < Test::Unit::TestCase
       orig = ->(s) { s.shout }
       r = nil
       GC.stress = true
-      6.times { |i| r = orig.dup_with_refinements(i.even? ? M1 : M2) }
+      6.times { |i| r = orig.with_refinements(i.even? ? M1 : M2) }
       GC.stress = false
       raise "bad" unless r.call("Hi") == "hi"
     RUBY
   end
 
-  def test_dup_with_refinements_iseq_to_binary
+  def test_with_refinements_iseq_to_binary
     # The memo shares a body slot with mandatory_only_iseq (discriminated by
     # iseq type); a block iseq that carries a memo must still serialize cleanly
     # (the memo is transient and dumped as absent).
@@ -609,59 +609,59 @@ class TestProc < Test::Unit::TestCase
       module M
         refine(String) { def shout = upcase + "!" }
       end
-      src = 'x = ->(s) { s.shout }; x.dup_with_refinements(M).call("hi")'
+      src = 'x = ->(s) { s.shout }; x.with_refinements(M).call("hi")'
       iseq = RubyVM::InstructionSequence.compile(src)
-      eval(src) # runs dup_with_refinements, setting the memo on the block iseq
+      eval(src) # runs with_refinements, setting the memo on the block iseq
       bin = iseq.to_binary
       loaded = RubyVM::InstructionSequence.load_from_binary(bin)
       assert_equal("HI!", loaded.eval)
     RUBY
   end
 
-  module DupWithRefinementsModule2
+  module WithRefinementsModule2
     refine String do
       def shout = "?"
     end
   end
 
-  def test_dup_with_refinements_memoized
+  def test_with_refinements_memoized
     orig = ->(s) { s.shout }
     # Repeating the same (proc, modules) reuses the cached copy but stays correct.
-    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
-    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
+    assert_equal("HI!", orig.with_refinements(WithRefinementsModule).call("hi"))
+    assert_equal("HI!", orig.with_refinements(WithRefinementsModule).call("hi"))
     # A different module set must not return the previously cached copy.
-    assert_equal("?", orig.dup_with_refinements(DupWithRefinementsModule2).call("hi"))
+    assert_equal("?", orig.with_refinements(WithRefinementsModule2).call("hi"))
     # ...and switching back is still correct.
-    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
+    assert_equal("HI!", orig.with_refinements(WithRefinementsModule).call("hi"))
   end
 
-  def test_dup_with_refinements_memo_distinct_environments
+  def test_with_refinements_memo_distinct_environments
     # Procs sharing the same block iseq but capturing different closure
     # environments hit the same memo entry (env is not part of the key), yet each
     # result must keep its own environment.
     factory = ->(tag) { ->(s) { "#{tag}:#{s.shout}" } }
     p1 = factory.call("A")
     p2 = factory.call("B")
-    r1 = p1.dup_with_refinements(DupWithRefinementsModule)
-    r2 = p2.dup_with_refinements(DupWithRefinementsModule)
+    r1 = p1.with_refinements(WithRefinementsModule)
+    r2 = p2.with_refinements(WithRefinementsModule)
     assert_equal("A:X!", r1.call("x"))
     assert_equal("B:Y!", r2.call("y"))
     # the original closures still see their own captured tag too
     assert_equal("A:X!", r1.call("x"))
   end
 
-  def test_dup_with_refinements_memo_avoids_recopy
+  def test_with_refinements_memo_avoids_recopy
     orig = ->(s) { s.shout }
-    orig.dup_with_refinements(DupWithRefinementsModule) # warm the memo
+    orig.with_refinements(WithRefinementsModule) # warm the memo
     GC.disable
     begin
       before = GC.stat(:total_allocated_objects)
-      100.times { orig.dup_with_refinements(DupWithRefinementsModule) }
+      100.times { orig.with_refinements(WithRefinementsModule) }
       hits = GC.stat(:total_allocated_objects) - before
 
       before = GC.stat(:total_allocated_objects)
       100.times do |i|
-        orig.dup_with_refinements(i.even? ? DupWithRefinementsModule : DupWithRefinementsModule2)
+        orig.with_refinements(i.even? ? WithRefinementsModule : WithRefinementsModule2)
       end
       misses = GC.stat(:total_allocated_objects) - before
     ensure

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -573,6 +573,60 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
+  module DupWithRefinementsModule2
+    refine String do
+      def shout = "?"
+    end
+  end
+
+  def test_dup_with_refinements_memoized
+    orig = ->(s) { s.shout }
+    # Repeating the same (proc, modules) reuses the cached copy but stays correct.
+    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
+    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
+    # A different module set must not return the previously cached copy.
+    assert_equal("?", orig.dup_with_refinements(DupWithRefinementsModule2).call("hi"))
+    # ...and switching back is still correct.
+    assert_equal("HI!", orig.dup_with_refinements(DupWithRefinementsModule).call("hi"))
+  end
+
+  def test_dup_with_refinements_memo_distinct_environments
+    # Procs sharing the same block iseq but capturing different closure
+    # environments hit the same memo entry (env is not part of the key), yet each
+    # result must keep its own environment.
+    factory = ->(tag) { ->(s) { "#{tag}:#{s.shout}" } }
+    p1 = factory.call("A")
+    p2 = factory.call("B")
+    r1 = p1.dup_with_refinements(DupWithRefinementsModule)
+    r2 = p2.dup_with_refinements(DupWithRefinementsModule)
+    assert_equal("A:X!", r1.call("x"))
+    assert_equal("B:Y!", r2.call("y"))
+    # the original closures still see their own captured tag too
+    assert_equal("A:X!", r1.call("x"))
+  end
+
+  def test_dup_with_refinements_memo_avoids_recopy
+    orig = ->(s) { s.shout }
+    orig.dup_with_refinements(DupWithRefinementsModule) # warm the memo
+    GC.disable
+    begin
+      before = GC.stat(:total_allocated_objects)
+      100.times { orig.dup_with_refinements(DupWithRefinementsModule) }
+      hits = GC.stat(:total_allocated_objects) - before
+
+      before = GC.stat(:total_allocated_objects)
+      100.times do |i|
+        orig.dup_with_refinements(i.even? ? DupWithRefinementsModule : DupWithRefinementsModule2)
+      end
+      misses = GC.stat(:total_allocated_objects) - before
+    ensure
+      GC.enable
+    end
+    # Memo hits must allocate far less than recomputing the iseq copy each time.
+    assert_operator(misses, :>, hits * 2,
+                    "expected memo hits (#{hits}) to allocate much less than misses (#{misses})")
+  end
+
   def test_clone_subclass
     c1 = Class.new(Proc)
     assert_equal c1, c1.new{}.clone.class, '[Bug #17545]'

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -584,17 +584,20 @@ class TestProc < Test::Unit::TestCase
   end
 
   def test_dup_with_refinements_gc_stress
-    # Under GC.stress, the allocation of the memo's module array used to run a
-    # GC that marked a half-initialized memo (argc set, mods not yet allocated).
+    # Under GC.stress, the memo store allocates its module array while the memo
+    # is reachable from the iseq; a GC during that allocation must not observe a
+    # half-initialized memo (argc set but mods not yet allocated).  Alternating
+    # module sets keeps missing the memo so each call re-runs the store; one
+    # small iseq keeps it cheap enough for slow CI runners.
     assert_normal_exit(<<~RUBY)
-      module M
-        refine(String) { def shout = upcase + "!" }
-      end
+      module M1; refine(String) { def shout = upcase + "!" }; end
+      module M2; refine(String) { def shout = downcase }; end
+      orig = ->(s) { s.shout }
+      r = nil
       GC.stress = true
-      # distinct source iseqs, each memoized once (the insert path)
-      refs = 50.times.map { |i| eval("->(s){ s.shout }").dup_with_refinements(M) }
+      6.times { |i| r = orig.dup_with_refinements(i.even? ? M1 : M2) }
       GC.stress = false
-      refs.each { |pr| raise "bad" unless pr.call("a") == "A!" }
+      raise "bad" unless r.call("Hi") == "hi"
     RUBY
   end
 

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -573,6 +573,21 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
+  def test_dup_with_refinements_gc_stress
+    # Under GC.stress, the allocation of the memo's module array used to run a
+    # GC that marked a half-initialized memo (argc set, mods not yet allocated).
+    assert_normal_exit(<<~RUBY)
+      module M
+        refine(String) { def shout = upcase + "!" }
+      end
+      GC.stress = true
+      # distinct source iseqs, each memoized once (the insert path)
+      refs = 50.times.map { |i| eval("->(s){ s.shout }").dup_with_refinements(M) }
+      GC.stress = false
+      refs.each { |pr| raise "bad" unless pr.call("a") == "A!" }
+    RUBY
+  end
+
   module DupWithRefinementsModule2
     refine String do
       def shout = "?"

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -533,6 +533,16 @@ class TestProc < Test::Unit::TestCase
     assert_equal(["P!", "Q!"], forwarded)
   end
 
+  def test_dup_with_refinements_via_c_call_paths
+    refined = ->(s) { s.shout }.dup_with_refinements(DupWithRefinementsModule)
+    # These reach the proc via the C invocation path (rb_vm_invoke_proc) rather
+    # than the optimized opt_call, so the refinement cref must be carried there.
+    assert_equal("A!", refined.send(:call, "a"))
+    assert_equal("B!", refined.method(:call).call("b"))
+    assert_equal("C!", Fiber.new(&refined).resume("c"))
+    assert_equal("D!", Thread.new("d", &refined).value)
+  end
+
   def test_dup_with_refinements_instance_eval
     refined = proc { self.shout }.dup_with_refinements(DupWithRefinementsModule)
     assert_equal("HI!", "hi".instance_eval(&refined))

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -588,6 +588,23 @@ class TestProc < Test::Unit::TestCase
     RUBY
   end
 
+  def test_dup_with_refinements_iseq_to_binary
+    # The memo shares a body slot with mandatory_only_iseq (discriminated by
+    # iseq type); a block iseq that carries a memo must still serialize cleanly
+    # (the memo is transient and dumped as absent).
+    assert_separately([], <<~'RUBY')
+      module M
+        refine(String) { def shout = upcase + "!" }
+      end
+      src = 'x = ->(s) { s.shout }; x.dup_with_refinements(M).call("hi")'
+      iseq = RubyVM::InstructionSequence.compile(src)
+      eval(src) # runs dup_with_refinements, setting the memo on the block iseq
+      bin = iseq.to_binary
+      loaded = RubyVM::InstructionSequence.load_from_binary(bin)
+      assert_equal("HI!", loaded.eval)
+    RUBY
+  end
+
   module DupWithRefinementsModule2
     refine String do
       def shout = "?"

--- a/thread.c
+++ b/thread.c
@@ -574,7 +574,8 @@ rb_vm_proc_local_ep(VALUE proc)
 
 // for ractor, defined in vm.c
 VALUE rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-                                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler);
+                                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                                  const rb_cref_t *cref);
 
 static VALUE
 thread_do_start_proc(rb_thread_t *th)
@@ -585,6 +586,7 @@ thread_do_start_proc(rb_thread_t *th)
     VALUE procval = th->invoke_arg.proc.proc;
     rb_proc_t *proc;
     GetProcPtr(procval, proc);
+    const rb_cref_t *cref = proc->has_refinements ? rb_proc_refinements_cref(procval) : NULL;
 
     th->ec->errinfo = Qnil;
     th->ec->root_lep = rb_vm_proc_local_ep(procval);
@@ -606,7 +608,8 @@ thread_do_start_proc(rb_thread_t *th)
             th->ec, proc, self,
             args_len, args_ptr,
             th->invoke_arg.proc.kw_splat,
-            VM_BLOCK_HANDLER_NONE
+            VM_BLOCK_HANDLER_NONE,
+            cref
         );
     }
     else {
@@ -627,7 +630,8 @@ thread_do_start_proc(rb_thread_t *th)
             th->ec, proc,
             args_len, args_ptr,
             th->invoke_arg.proc.kw_splat,
-            VM_BLOCK_HANDLER_NONE
+            VM_BLOCK_HANDLER_NONE,
+            cref
         );
     }
 }

--- a/vm.c
+++ b/vm.c
@@ -1367,7 +1367,7 @@ rb_proc_dup(VALUE self)
  * iseq) sharing `self`'s receiver and environment, but carrying `cref` as its
  * refinement cref.  The cref is injected into the frame at every proc-invocation
  * path so refinements take effect while the closure environment stays shared.
- * Used by Proc#dup_with_refinements.  Never marked shareable because the cref
+ * Used by Proc#with_refinements.  Never marked shareable because the cref
  * may reference non-shareable refinements. */
 VALUE
 rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref)
@@ -1985,11 +1985,11 @@ vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                      int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_callable_method_entry_t *me)
 {
     /* bmethod procs are invoked against the method entry, not the proc's cref,
-     * and dup_with_refinements rejects them, so there is never a cref here. */
+     * and with_refinements rejects them, so there is never a cref here. */
     return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, NULL, me);
 }
 
-/* `cref` carries a Proc#dup_with_refinements refinement cref (or NULL); callers
+/* `cref` carries a Proc#with_refinements refinement cref (or NULL); callers
  * that have the proc VALUE compute it via rb_proc_refinements_cref. */
 VALUE
 rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,

--- a/vm.c
+++ b/vm.c
@@ -359,8 +359,8 @@ ref_delete_symkey(VALUE key, VALUE value, VALUE unused)
     return SYMBOL_P(key) ? ST_DELETE : ST_CONTINUE;
 }
 
-static rb_cref_t *
-vm_cref_dup(const rb_cref_t *cref)
+rb_cref_t *
+rb_vm_cref_dup(const rb_cref_t *cref)
 {
     const rb_scope_visibility_t *visi = CREF_SCOPE_VISI(cref);
     rb_cref_t *next_cref = CREF_NEXT(cref), *new_cref;
@@ -396,12 +396,6 @@ rb_vm_cref_dup_without_refinements(const rb_cref_t *cref)
     }
 
     return new_cref;
-}
-
-rb_cref_t *
-rb_vm_cref_dup(const rb_cref_t *cref)
-{
-    return vm_cref_dup(cref);
 }
 
 static rb_cref_t *

--- a/vm.c
+++ b/vm.c
@@ -398,6 +398,12 @@ rb_vm_cref_dup_without_refinements(const rb_cref_t *cref)
     return new_cref;
 }
 
+rb_cref_t *
+rb_vm_cref_dup(const rb_cref_t *cref)
+{
+    return vm_cref_dup(cref);
+}
+
 static rb_cref_t *
 vm_cref_new_toplevel(rb_execution_context_t *ec)
 {
@@ -1354,8 +1360,38 @@ rb_proc_dup(VALUE self)
         break;
     }
 
+    if (src->cref) {
+        rb_proc_t *dst;
+        GetProcPtr(procval, dst);
+        RB_OBJ_WRITE(procval, &dst->cref, src->cref);
+    }
+
     if (RB_OBJ_SHAREABLE_P(self)) RB_OBJ_SET_SHAREABLE(procval);
     RB_GC_GUARD(self); /* for: body = rb_proc_dup(body) */
+    return procval;
+}
+
+/* Build a new Proc that runs `iseq` (a recursive copy of the original block
+ * iseq) sharing `self`'s receiver and environment, but carrying `cref` as its
+ * refinement cref.  The cref is injected into the frame at every proc-invocation
+ * path so refinements take effect while the closure environment stays shared.
+ * Used by Proc#dup_with_refinements.  Never marked shareable because the cref
+ * may reference non-shareable refinements. */
+VALUE
+rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref)
+{
+    rb_proc_t *src, *dst;
+    GetProcPtr(self, src);
+    VM_ASSERT(vm_block_type(&src->block) == block_type_iseq);
+
+    struct rb_block block = src->block;
+    block.as.captured.code.iseq = iseq;
+
+    VALUE procval = proc_create(rb_obj_class(self), &block, src->is_from_method, src->is_lambda);
+    GetProcPtr(procval, dst);
+    RB_OBJ_WRITE(procval, &dst->cref, cref);
+
+    RB_GC_GUARD(self);
     return procval;
 }
 
@@ -1841,11 +1877,17 @@ invoke_block_from_c_bh(rb_execution_context_t *ec, VALUE block_handler,
         return vm_yield_with_symbol(ec, VM_BH_TO_SYMBOL(block_handler),
                                     argc, argv, kw_splat, passed_block_handler);
       case block_handler_type_proc:
-        if (force_blockarg == FALSE) {
-            is_lambda = block_proc_is_lambda(VM_BH_TO_PROC(block_handler));
+        {
+            VALUE proc = VM_BH_TO_PROC(block_handler);
+            rb_proc_t *po;
+            GetProcPtr(proc, po);
+            if (po->cref) cref = po->cref; /* carry refinement cref into the block frame */
+            if (force_blockarg == FALSE) {
+                is_lambda = block_proc_is_lambda(proc);
+            }
+            block_handler = vm_proc_to_block_handler(proc);
+            goto again;
         }
-        block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
-        goto again;
     }
     VM_UNREACHABLE(invoke_block_from_c_splattable);
     return Qundef;
@@ -1909,7 +1951,7 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
   again:
     switch (vm_block_type(block)) {
       case block_type_iseq:
-        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, NULL, is_lambda, me);
+        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, proc->cref, is_lambda, me);
       case block_type_ifunc:
         if (kw_splat == 1) {
             VALUE keyword_hash = argv[argc-1];

--- a/vm.c
+++ b/vm.c
@@ -453,7 +453,7 @@ static VALUE vm_make_env_object(const rb_execution_context_t *ec, rb_control_fra
 static VALUE vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                                   int argc, const VALUE *argv, int kw_splat, VALUE block_handler,
                                   const rb_callable_method_entry_t *me);
-static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
+static VALUE vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self, int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_cref_t *cref);
 
 #if USE_YJIT
 // Counter to serve as a proxy for execution time, total number of calls
@@ -1354,10 +1354,8 @@ rb_proc_dup(VALUE self)
         break;
     }
 
-    if (src->cref) {
-        rb_proc_t *dst;
-        GetProcPtr(procval, dst);
-        RB_OBJ_WRITE(procval, &dst->cref, src->cref);
+    if (src->has_refinements) {
+        rb_proc_set_refinements_cref(procval, rb_proc_refinements_cref(self));
     }
 
     if (RB_OBJ_SHAREABLE_P(self)) RB_OBJ_SET_SHAREABLE(procval);
@@ -1374,7 +1372,7 @@ rb_proc_dup(VALUE self)
 VALUE
 rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref)
 {
-    rb_proc_t *src, *dst;
+    rb_proc_t *src;
     GetProcPtr(self, src);
     VM_ASSERT(vm_block_type(&src->block) == block_type_iseq);
 
@@ -1382,8 +1380,7 @@ rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_
     block.as.captured.code.iseq = iseq;
 
     VALUE procval = proc_create(rb_obj_class(self), &block, src->is_from_method, src->is_lambda);
-    GetProcPtr(procval, dst);
-    RB_OBJ_WRITE(procval, &dst->cref, cref);
+    rb_proc_set_refinements_cref(procval, cref);
 
     RB_GC_GUARD(self);
     return procval;
@@ -1874,9 +1871,10 @@ invoke_block_from_c_bh(rb_execution_context_t *ec, VALUE block_handler,
         {
             /* Fetch the proc pointer once and reuse it for the refinement cref,
              * is_lambda, and the block-handler conversion. */
+            VALUE procval = VM_BH_TO_PROC(block_handler);
             rb_proc_t *po;
-            GetProcPtr(VM_BH_TO_PROC(block_handler), po);
-            if (po->cref) cref = po->cref; /* carry refinement cref into the block frame */
+            GetProcPtr(procval, po);
+            if (po->has_refinements) cref = rb_proc_refinements_cref(procval); /* into the block frame */
             if (force_blockarg == FALSE) {
                 is_lambda = po->is_lambda;
             }
@@ -1933,12 +1931,14 @@ ALWAYS_INLINE(static VALUE
               invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
                                        VALUE self, int argc, const VALUE *argv,
                                        int kw_splat, VALUE passed_block_handler, int is_lambda,
+                                       const rb_cref_t *cref,
                                        const rb_callable_method_entry_t *me));
 
 static inline VALUE
 invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
                          VALUE self, int argc, const VALUE *argv,
                          int kw_splat, VALUE passed_block_handler, int is_lambda,
+                         const rb_cref_t *cref,
                          const rb_callable_method_entry_t *me)
 {
     const struct rb_block *block = &proc->block;
@@ -1946,7 +1946,7 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
   again:
     switch (vm_block_type(block)) {
       case block_type_iseq:
-        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, proc->cref, is_lambda, me);
+        return invoke_iseq_block_from_c(ec, &block->as.captured, self, argc, argv, kw_splat, passed_block_handler, cref, is_lambda, me);
       case block_type_ifunc:
         if (kw_splat == 1) {
             VALUE keyword_hash = argv[argc-1];
@@ -1974,21 +1974,27 @@ invoke_block_from_c_proc(rb_execution_context_t *ec, const rb_proc_t *proc,
 
 static VALUE
 vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-               int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+               int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+               const rb_cref_t *cref)
 {
-    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, NULL);
+    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, proc->is_lambda, cref, NULL);
 }
 
 static VALUE
 vm_invoke_bmethod(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
                      int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_callable_method_entry_t *me)
 {
-    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, me);
+    /* bmethod procs are invoked against the method entry, not the proc's cref,
+     * and dup_with_refinements rejects them, so there is never a cref here. */
+    return invoke_block_from_c_proc(ec, proc, self, argc, argv, kw_splat, block_handler, TRUE, NULL, me);
 }
 
+/* `cref` carries a Proc#dup_with_refinements refinement cref (or NULL); callers
+ * that have the proc VALUE compute it via rb_proc_refinements_cref. */
 VALUE
 rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
-                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+                  int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                  const rb_cref_t *cref)
 {
     VALUE self = vm_block_self(&proc->block);
     vm_block_handler_verify(passed_block_handler);
@@ -1997,13 +2003,14 @@ rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc,
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {
-        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler);
+        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, cref);
     }
 }
 
 VALUE
 rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE self,
-                            int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler)
+                            int argc, const VALUE *argv, int kw_splat, VALUE passed_block_handler,
+                            const rb_cref_t *cref)
 {
     vm_block_handler_verify(passed_block_handler);
 
@@ -2011,7 +2018,7 @@ rb_vm_invoke_proc_with_self(rb_execution_context_t *ec, rb_proc_t *proc, VALUE s
         return vm_invoke_bmethod(ec, proc, self, argc, argv, kw_splat, passed_block_handler, NULL);
     }
     else {
-        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler);
+        return vm_invoke_proc(ec, proc, self, argc, argv, kw_splat, passed_block_handler, cref);
     }
 }
 

--- a/vm.c
+++ b/vm.c
@@ -1872,14 +1872,15 @@ invoke_block_from_c_bh(rb_execution_context_t *ec, VALUE block_handler,
                                     argc, argv, kw_splat, passed_block_handler);
       case block_handler_type_proc:
         {
-            VALUE proc = VM_BH_TO_PROC(block_handler);
+            /* Fetch the proc pointer once and reuse it for the refinement cref,
+             * is_lambda, and the block-handler conversion. */
             rb_proc_t *po;
-            GetProcPtr(proc, po);
+            GetProcPtr(VM_BH_TO_PROC(block_handler), po);
             if (po->cref) cref = po->cref; /* carry refinement cref into the block frame */
             if (force_blockarg == FALSE) {
-                is_lambda = block_proc_is_lambda(proc);
+                is_lambda = po->is_lambda;
             }
-            block_handler = vm_proc_to_block_handler(proc);
+            block_handler = vm_block_to_block_handler(&po->block);
             goto again;
         }
     }

--- a/vm_core.h
+++ b/vm_core.h
@@ -1319,11 +1319,21 @@ extern const rb_data_type_t ruby_proc_data_type;
 
 typedef struct {
     const struct rb_block block;
-    const rb_cref_t *cref;              /* cref with refinements; NULL for ordinary procs */
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */
+    /* Set when the proc carries a Proc#dup_with_refinements refinement cref.
+     * The cref itself is stored in a hidden instance variable on the proc
+     * object (see proc.c) rather than here, to avoid growing rb_proc_t for the
+     * common case; this bit gates the lookup. */
+    unsigned int has_refinements: 1;    /* bool */
 } rb_proc_t;
+
+/* Proc#dup_with_refinements: the refinement cref lives in a hidden ivar on the
+ * proc object, gated by rb_proc_t::has_refinements.  rb_proc_refinements_cref
+ * assumes the bit is set (callers check it on the fast path). */
+const rb_cref_t *rb_proc_refinements_cref(VALUE procval);
+void rb_proc_set_refinements_cref(VALUE procval, const rb_cref_t *cref);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_proc_isolate(VALUE self);
@@ -1980,7 +1990,7 @@ void rb_iseq_pathobj_set(const rb_iseq_t *iseq, VALUE path, VALUE realpath);
 int rb_ec_frame_method_id_and_class(const rb_execution_context_t *ec, ID *idp, ID *called_idp, VALUE *klassp);
 void rb_ec_setup_exception(const rb_execution_context_t *ec, VALUE mesg, VALUE cause);
 
-VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, int kw_splat, VALUE block_handler);
+VALUE rb_vm_invoke_proc(rb_execution_context_t *ec, rb_proc_t *proc, int argc, const VALUE *argv, int kw_splat, VALUE block_handler, const rb_cref_t *cref);
 
 VALUE rb_vm_make_proc_lambda(const rb_execution_context_t *ec, const struct rb_captured_block *captured, VALUE klass, int8_t is_lambda);
 static inline VALUE

--- a/vm_core.h
+++ b/vm_core.h
@@ -556,11 +556,11 @@ struct rb_iseq_constant_body {
      *     mandatory-only optimized variant (set only for methods that use the
      *     __builtin.mandatory_only? optimization).
      *   - refinement_memo: for ISEQ_TYPE_BLOCK, the single-entry
-     *     Proc#dup_with_refinements memo caching the most recent
+     *     Proc#with_refinements memo caching the most recent
      *     {copied iseq, cref} pair for a given (base_cref, modules) key.  NULL
-     *     unless this block iseq has been a Proc#dup_with_refinements source.
+     *     unless this block iseq has been a Proc#with_refinements source.
      * A block iseq never has a mandatory-only variant and only block iseqs are
-     * dup_with_refinements sources, so discriminate with
+     * with_refinements sources, so discriminate with
      * ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK. */
     union {
         const rb_iseq_t *mandatory_only_iseq;
@@ -1322,14 +1322,14 @@ typedef struct {
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */
-    /* Set when the proc carries a Proc#dup_with_refinements refinement cref.
+    /* Set when the proc carries a Proc#with_refinements refinement cref.
      * The cref itself is stored in a hidden instance variable on the proc
      * object (see proc.c) rather than here, to avoid growing rb_proc_t for the
      * common case; this bit gates the lookup. */
     unsigned int has_refinements: 1;    /* bool */
 } rb_proc_t;
 
-/* Proc#dup_with_refinements: the refinement cref lives in a hidden ivar on the
+/* Proc#with_refinements: the refinement cref lives in a hidden ivar on the
  * proc object, gated by rb_proc_t::has_refinements.  rb_proc_refinements_cref
  * assumes the bit is set (callers check it on the fast path). */
 const rb_cref_t *rb_proc_refinements_cref(VALUE procval);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1304,6 +1304,7 @@ extern const rb_data_type_t ruby_proc_data_type;
 
 typedef struct {
     const struct rb_block block;
+    const rb_cref_t *cref;              /* cref with refinements; NULL for ordinary procs */
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */

--- a/vm_core.h
+++ b/vm_core.h
@@ -550,8 +550,8 @@ struct rb_iseq_constant_body {
 
     struct rb_id_table *outer_variables;
 
-    /* This slot holds different things for different iseq types, which never
-     * coexist, so they share storage (no per-iseq size cost):
+    /* Optimization slot shared by mutually-exclusive iseq types, so it adds no
+     * per-iseq size:
      *   - mandatory_only_iseq: for ISEQ_TYPE_METHOD, the body of the
      *     mandatory-only optimized variant (set only for methods that use the
      *     __builtin.mandatory_only? optimization).
@@ -565,7 +565,7 @@ struct rb_iseq_constant_body {
     union {
         const rb_iseq_t *mandatory_only_iseq;
         struct rb_iseq_refinement_memo *refinement_memo;
-    };
+    } opt;
 
 #if USE_YJIT || USE_ZJIT
     // Function pointer for JIT code on jit_exec()

--- a/vm_core.h
+++ b/vm_core.h
@@ -550,13 +550,22 @@ struct rb_iseq_constant_body {
 
     struct rb_id_table *outer_variables;
 
-    const rb_iseq_t *mandatory_only_iseq;
-
-    /* Single-entry memo for Proc#dup_with_refinements: caches the most recent
-     * {copied iseq, cref} pair produced from this iseq for a given
-     * (base_cref, modules) key.  NULL unless this iseq has been the source of a
-     * Proc#dup_with_refinements call. */
-    struct rb_iseq_refinement_memo *refinement_memo;
+    /* This slot holds different things for different iseq types, which never
+     * coexist, so they share storage (no per-iseq size cost):
+     *   - mandatory_only_iseq: for ISEQ_TYPE_METHOD, the body of the
+     *     mandatory-only optimized variant (set only for methods that use the
+     *     __builtin.mandatory_only? optimization).
+     *   - refinement_memo: for ISEQ_TYPE_BLOCK, the single-entry
+     *     Proc#dup_with_refinements memo caching the most recent
+     *     {copied iseq, cref} pair for a given (base_cref, modules) key.  NULL
+     *     unless this block iseq has been a Proc#dup_with_refinements source.
+     * A block iseq never has a mandatory-only variant and only block iseqs are
+     * dup_with_refinements sources, so discriminate with
+     * ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK. */
+    union {
+        const rb_iseq_t *mandatory_only_iseq;
+        struct rb_iseq_refinement_memo *refinement_memo;
+    };
 
 #if USE_YJIT || USE_ZJIT
     // Function pointer for JIT code on jit_exec()

--- a/vm_core.h
+++ b/vm_core.h
@@ -552,6 +552,12 @@ struct rb_iseq_constant_body {
 
     const rb_iseq_t *mandatory_only_iseq;
 
+    /* Single-entry memo for Proc#dup_with_refinements: caches the most recent
+     * {copied iseq, cref} pair produced from this iseq for a given
+     * (base_cref, modules) key.  NULL unless this iseq has been the source of a
+     * Proc#dup_with_refinements call. */
+    struct rb_iseq_refinement_memo *refinement_memo;
+
 #if USE_YJIT || USE_ZJIT
     // Function pointer for JIT code on jit_exec()
     rb_jit_func_t jit_entry;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -290,7 +290,8 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
             {
                 rb_proc_t *proc;
                 GetProcPtr(calling->recv, proc);
-                ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler);
+                ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler,
+                                        proc->has_refinements ? rb_proc_refinements_cref(calling->recv) : NULL);
                 goto success;
             }
           case OPTIMIZED_METHOD_TYPE_STRUCT_AREF:
@@ -2234,9 +2235,11 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
           case block_handler_type_proc:
             is_lambda = rb_proc_lambda_p(block_handler) != Qfalse;
             {
+                VALUE procval = VM_BH_TO_PROC(block_handler);
                 rb_proc_t *po;
-                GetProcPtr(VM_BH_TO_PROC(block_handler), po);
-                proc_cref = po->cref; /* Proc#dup_with_refinements refinement cref, if any */
+                GetProcPtr(procval, po);
+                /* Proc#dup_with_refinements refinement cref, if any */
+                if (po->has_refinements) proc_cref = rb_proc_refinements_cref(procval);
             }
             block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
             goto again;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2216,6 +2216,7 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
     const VALUE *ep = NULL;
     rb_cref_t *cref;
     int is_lambda = FALSE;
+    const rb_cref_t *proc_cref = NULL;
 
     if (block_handler != VM_BLOCK_HANDLER_NONE) {
       again:
@@ -2232,6 +2233,11 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
             break;
           case block_handler_type_proc:
             is_lambda = rb_proc_lambda_p(block_handler) != Qfalse;
+            {
+                rb_proc_t *po;
+                GetProcPtr(VM_BH_TO_PROC(block_handler), po);
+                proc_cref = po->cref; /* Proc#dup_with_refinements refinement cref, if any */
+            }
             block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
             goto again;
           case block_handler_type_symbol:
@@ -2248,6 +2254,13 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
 
     VM_ASSERT(singleton || RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_CLASS));
     cref = vm_cref_push(ec, self, ep, TRUE, singleton);
+
+    /* Keep the block's refinements active inside instance_eval/instance_exec etc.
+     * when the block came from Proc#dup_with_refinements (its cref is carried on
+     * the proc, not in the captured environment that vm_cref_push reads). */
+    if (proc_cref && !NIL_P(CREF_REFINEMENTS(proc_cref))) {
+        CREF_REFINEMENTS_SET(cref, CREF_REFINEMENTS(proc_cref));
+    }
 
     return vm_yield_with_cref(ec, argc, argv, kw_splat, cref, is_lambda);
 }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2004,7 +2004,7 @@ eval_string_with_cref(VALUE self, VALUE src, rb_cref_t *cref, VALUE file, int li
     /* TODO: what the code checking? */
     if (!cref && block.as.captured.code.val) {
         rb_cref_t *orig_cref = vm_get_cref(vm_block_ep(&block));
-        cref = vm_cref_dup(orig_cref);
+        cref = rb_vm_cref_dup(orig_cref);
     }
     vm_set_eval_stack(ec, iseq, cref, &block);
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2238,7 +2238,7 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
                 VALUE procval = VM_BH_TO_PROC(block_handler);
                 rb_proc_t *po;
                 GetProcPtr(procval, po);
-                /* Proc#dup_with_refinements refinement cref, if any */
+                /* Proc#with_refinements refinement cref, if any */
                 if (po->has_refinements) proc_cref = rb_proc_refinements_cref(procval);
             }
             block_handler = vm_proc_to_block_handler(VM_BH_TO_PROC(block_handler));
@@ -2259,7 +2259,7 @@ yield_under(VALUE self, int singleton, int argc, const VALUE *argv, int kw_splat
     cref = vm_cref_push(ec, self, ep, TRUE, singleton);
 
     /* Keep the block's refinements active inside instance_eval/instance_exec etc.
-     * when the block came from Proc#dup_with_refinements (its cref is carried on
+     * when the block came from Proc#with_refinements (its cref is carried on
      * the proc, not in the captured environment that vm_cref_push reads). */
     if (proc_cref && !NIL_P(CREF_REFINEMENTS(proc_cref))) {
         CREF_REFINEMENTS_SET(cref, CREF_REFINEMENTS(proc_cref));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5265,9 +5265,9 @@ vm_yield_setup_args(rb_execution_context_t *ec, const rb_iseq_t *iseq, const int
 /* ruby iseq -> ruby block */
 
 static VALUE
-vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
-                     struct rb_calling_info *calling, const struct rb_callinfo *ci,
-                     bool is_lambda, VALUE block_handler)
+vm_invoke_iseq_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref)
 {
     const struct rb_captured_block *captured = VM_BH_TO_ISEQ_BLOCK(block_handler);
     const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
@@ -5279,15 +5279,25 @@ vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
 
     SET_SP(rsp);
 
+    /* `cref` is normally 0; Proc#dup_with_refinements supplies a refinement cref
+     * so that method calls inside the block resolve against it. */
     vm_push_frame(ec, iseq,
                   frame_flag,
                   captured->self,
-                  VM_GUARDED_PREV_EP(captured->ep), 0,
+                  VM_GUARDED_PREV_EP(captured->ep), (VALUE)cref,
                   ISEQ_BODY(iseq)->iseq_encoded + opt_pc,
                   rsp + arg_size,
                   ISEQ_BODY(iseq)->local_table_size - arg_size, ISEQ_BODY(iseq)->stack_max);
 
     return Qundef;
+}
+
+static VALUE
+vm_invoke_iseq_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                     struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                     bool is_lambda, VALUE block_handler)
+{
+    return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, NULL);
 }
 
 static VALUE
@@ -5377,10 +5387,19 @@ vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                      struct rb_calling_info *calling, const struct rb_callinfo *ci,
                      bool is_lambda, VALUE block_handler)
 {
+    const rb_cref_t *cref = NULL;
+
     while (vm_block_handler_type(block_handler) == block_handler_type_proc) {
         VALUE proc = VM_BH_TO_PROC(block_handler);
+        rb_proc_t *po;
+        GetProcPtr(proc, po);
+        cref = po->cref; /* innermost proc's refinement cref, if any */
         is_lambda = block_proc_is_lambda(proc);
         block_handler = vm_proc_to_block_handler(proc);
+    }
+
+    if (cref && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
+        return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
     }
 
     return vm_invoke_block(ec, reg_cfp, calling, ci, is_lambda, block_handler);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -908,7 +908,7 @@ cref_replace_with_duplicated_cref_each_frame(const VALUE *vptr, int can_be_svar,
         switch (imemo_type(v)) {
           case imemo_cref:
             cref = (rb_cref_t *)v;
-            new_cref = vm_cref_dup(cref);
+            new_cref = rb_vm_cref_dup(cref);
             if (parent) {
                 RB_OBJ_WRITE(parent, vptr, new_cref);
             }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5392,12 +5392,13 @@ vm_proc_to_block_handler(VALUE procval)
 NOINLINE(static VALUE
 vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                                struct rb_calling_info *calling, const struct rb_callinfo *ci,
-                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref));
+                               bool is_lambda, VALUE block_handler, VALUE refined_procval));
 static VALUE
 vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                                struct rb_calling_info *calling, const struct rb_callinfo *ci,
-                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref)
+                               bool is_lambda, VALUE block_handler, VALUE refined_procval)
 {
+    const rb_cref_t *cref = rb_proc_refinements_cref(refined_procval);
     return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
 }
 
@@ -5406,22 +5407,25 @@ vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                      struct rb_calling_info *calling, const struct rb_callinfo *ci,
                      bool is_lambda, VALUE block_handler)
 {
-    const rb_cref_t *cref = NULL;
+    VALUE refined_procval = 0;
 
     /* Fetch the proc pointer once per iteration and reuse it for is_lambda, the
-     * refinement cref, and the block-handler conversion (cref is NULL for
-     * ordinary procs). */
+     * refinement flag, and the block-handler conversion.  Only remember which
+     * proc carried refinements; the cref itself is fetched on the rare path
+     * below, so this hot loop stays call-free and the common ordinary-proc path
+     * keeps vm_invoke_proc_block leaf/frameless (no prologue per pr.call). */
     while (vm_block_handler_type(block_handler) == block_handler_type_proc) {
         VALUE procval = VM_BH_TO_PROC(block_handler);
         rb_proc_t *po;
         GetProcPtr(procval, po);
-        cref = po->has_refinements ? rb_proc_refinements_cref(procval) : NULL;
+        if (po->has_refinements) refined_procval = procval;
         is_lambda = po->is_lambda;
         block_handler = vm_block_to_block_handler(&po->block);
     }
 
-    if (UNLIKELY(cref) && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
-        return vm_invoke_proc_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
+    if (UNLIKELY(refined_procval) && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
+        return vm_invoke_proc_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler,
+                                              refined_procval);
     }
 
     return vm_invoke_block(ec, reg_cfp, calling, ci, is_lambda, block_handler);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5279,7 +5279,7 @@ vm_invoke_iseq_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *r
 
     SET_SP(rsp);
 
-    /* `cref` is normally 0; Proc#dup_with_refinements supplies a refinement cref
+    /* `cref` is normally 0; Proc#with_refinements supplies a refinement cref
      * so that method calls inside the block resolve against it. */
     vm_push_frame(ec, iseq,
                   frame_flag,
@@ -5386,7 +5386,7 @@ vm_proc_to_block_handler(VALUE procval)
     return vm_block_to_block_handler(vm_proc_block(procval));
 }
 
-/* Rare path: an inner proc carried a refinement cref (Proc#dup_with_refinements).
+/* Rare path: an inner proc carried a refinement cref (Proc#with_refinements).
  * Kept out of line so the common proc-as-block invocation below stays small and
  * does not inline the iseq-block frame setup. */
 NOINLINE(static VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5363,11 +5363,9 @@ vm_invoke_ifunc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
     return val;
 }
 
-static VALUE
-vm_proc_to_block_handler(VALUE procval)
+static inline VALUE
+vm_block_to_block_handler(const struct rb_block *block)
 {
-    const struct rb_block *block = vm_proc_block(procval);
-
     switch (vm_block_type(block)) {
       case block_type_iseq:
         return VM_BH_FROM_ISEQ_BLOCK(&block->as.captured);
@@ -5383,23 +5381,46 @@ vm_proc_to_block_handler(VALUE procval)
 }
 
 static VALUE
+vm_proc_to_block_handler(VALUE procval)
+{
+    return vm_block_to_block_handler(vm_proc_block(procval));
+}
+
+/* Rare path: an inner proc carried a refinement cref (Proc#dup_with_refinements).
+ * Kept out of line so the common proc-as-block invocation below stays small and
+ * does not inline the iseq-block frame setup. */
+NOINLINE(static VALUE
+vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref));
+static VALUE
+vm_invoke_proc_block_with_cref(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
+                               struct rb_calling_info *calling, const struct rb_callinfo *ci,
+                               bool is_lambda, VALUE block_handler, const rb_cref_t *cref)
+{
+    return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
+}
+
+static VALUE
 vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
                      struct rb_calling_info *calling, const struct rb_callinfo *ci,
                      bool is_lambda, VALUE block_handler)
 {
     const rb_cref_t *cref = NULL;
 
+    /* Fetch the proc pointer once per iteration and reuse it for is_lambda, the
+     * refinement cref, and the block-handler conversion (cref is NULL for
+     * ordinary procs). */
     while (vm_block_handler_type(block_handler) == block_handler_type_proc) {
-        VALUE proc = VM_BH_TO_PROC(block_handler);
         rb_proc_t *po;
-        GetProcPtr(proc, po);
-        cref = po->cref; /* innermost proc's refinement cref, if any */
-        is_lambda = block_proc_is_lambda(proc);
-        block_handler = vm_proc_to_block_handler(proc);
+        GetProcPtr(VM_BH_TO_PROC(block_handler), po);
+        cref = po->cref;
+        is_lambda = po->is_lambda;
+        block_handler = vm_block_to_block_handler(&po->block);
     }
 
-    if (cref && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
-        return vm_invoke_iseq_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
+    if (UNLIKELY(cref) && vm_block_handler_type(block_handler) == block_handler_type_iseq) {
+        return vm_invoke_proc_block_with_cref(ec, reg_cfp, calling, ci, is_lambda, block_handler, cref);
     }
 
     return vm_invoke_block(ec, reg_cfp, calling, ci, is_lambda, block_handler);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5412,9 +5412,10 @@ vm_invoke_proc_block(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp,
      * refinement cref, and the block-handler conversion (cref is NULL for
      * ordinary procs). */
     while (vm_block_handler_type(block_handler) == block_handler_type_proc) {
+        VALUE procval = VM_BH_TO_PROC(block_handler);
         rb_proc_t *po;
-        GetProcPtr(VM_BH_TO_PROC(block_handler), po);
-        cref = po->cref;
+        GetProcPtr(procval, po);
+        cref = po->has_refinements ? rb_proc_refinements_cref(procval) : NULL;
         is_lambda = po->is_lambda;
         block_handler = vm_block_to_block_handler(&po->block);
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -1099,7 +1099,7 @@ rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *de
                     METHOD_ENTRY_BASIC_SET((rb_method_entry_t *)me, TRUE);
                 }
 
-                if (ISEQ_BODY(iseq)->mandatory_only_iseq) def->iseq_overload = 1;
+                if (ISEQ_BODY(iseq)->opt.mandatory_only_iseq) def->iseq_overload = 1;
 
                 if (0) vm_cref_dump("rb_method_definition_create", cref);
 
@@ -1662,7 +1662,7 @@ get_overloaded_cme(const rb_callable_method_entry_t *cme)
                                                       false);
 
         RB_OBJ_WRITE(me, &def->body.iseq.cref, cme->def->body.iseq.cref);
-        RB_OBJ_WRITE(me, &def->body.iseq.iseqptr, ISEQ_BODY(cme->def->body.iseq.iseqptr)->mandatory_only_iseq);
+        RB_OBJ_WRITE(me, &def->body.iseq.iseqptr, ISEQ_BODY(cme->def->body.iseq.iseqptr)->opt.mandatory_only_iseq);
 
         ASSERT_vm_locking();
         st_insert(overloaded_cme_table(), (st_data_t)cme, (st_data_t)me);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -529,6 +529,7 @@ pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
 pub struct rb_proc_t {
     pub block: rb_block,
+    pub cref: *const rb_cref_t,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 7usize],

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -529,7 +529,6 @@ pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
 pub struct rb_proc_t {
     pub block: rb_block,
-    pub cref: *const rb_cref_t,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 7usize],
@@ -569,10 +568,22 @@ impl rb_proc_t {
         }
     }
     #[inline]
+    pub fn has_refinements(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_has_refinements(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
     pub fn new_bitfield_1(
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
+        has_refinements: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -586,6 +597,10 @@ impl rb_proc_t {
         __bindgen_bitfield_unit.set(2usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let has_refinements: u32 = unsafe { ::std::mem::transmute(has_refinements) };
+            has_refinements as u64
         });
         __bindgen_bitfield_unit
     }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1318,6 +1318,7 @@ pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
 pub struct rb_proc_t {
     pub block: rb_block,
+    pub cref: *const rb_cref_t,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 7usize],

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1250,6 +1250,12 @@ pub union rb_iseq_constant_body__bindgen_ty_2 {
     pub single: iseq_bits_t,
 }
 #[repr(C)]
+#[derive(Copy, Clone)]
+pub union rb_iseq_constant_body__bindgen_ty_3 {
+    pub mandatory_only_iseq: *const rb_iseq_t,
+    pub refinement_memo: *mut rb_iseq_refinement_memo,
+}
+#[repr(C)]
 pub struct rb_iseq_struct {
     pub flags: VALUE,
     pub wrapper: VALUE,
@@ -1986,6 +1992,11 @@ pub type rb_iseq_param_keyword_struct =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct succ_index_table {
+    pub _address: u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rb_iseq_refinement_memo {
     pub _address: u8,
 }
 unsafe extern "C" {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -1318,7 +1318,6 @@ pub type rb_control_frame_t = rb_control_frame_struct;
 #[repr(C)]
 pub struct rb_proc_t {
     pub block: rb_block,
-    pub cref: *const rb_cref_t,
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 7usize],
@@ -1424,10 +1423,44 @@ impl rb_proc_t {
         }
     }
     #[inline]
+    pub fn has_refinements(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_has_refinements(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn has_refinements_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                3usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_has_refinements_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn new_bitfield_1(
         is_from_method: ::std::os::raw::c_uint,
         is_lambda: ::std::os::raw::c_uint,
         is_isolated: ::std::os::raw::c_uint,
+        has_refinements: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1441,6 +1474,10 @@ impl rb_proc_t {
         __bindgen_bitfield_unit.set(2usize, 1u8, {
             let is_isolated: u32 = unsafe { ::std::mem::transmute(is_isolated) };
             is_isolated as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let has_refinements: u32 = unsafe { ::std::mem::transmute(has_refinements) };
+            has_refinements as u64
         });
         __bindgen_bitfield_unit
     }


### PR DESCRIPTION
**New PR: https://github.com/ruby/ruby/pull/17248**

Add Proc#with_refinements(mod, ...), which returns a new Proc that behaves like the receiver but with the refinements activated by the given modules in effect inside its body, without affecting the original Proc. This is an alternative to the previously proposed Proc#using [Feature #16461] that does not modify the existing block and needs no `using Proc::Refinements` declaration.

Refinements are resolved at run time via the cref, so two pieces are needed:

* The refinement cref is carried on the Proc (new rb_proc_t::cref) and injected into the block frame on every proc-invocation path (Proc#call, yield from C methods, invokeblock/opt_call, and instance_eval/instance_exec/module_eval/class_eval via yield_under). The captured environment stays shared, so closure variables are still shared with the original Proc.

* The block's instruction sequences are recursively deep-copied (rb_iseq_dup_with_independent_caches) so the new Proc has its own inline method caches.  This is required for correctness: the VM caches refinement method resolution per call site assuming a single lexical cref per iseq, so sharing the iseq would leak the refined methods into the original Proc.

Procs without an iseq block (Symbol#to_proc, C-function procs) and procs created from methods are not supported and raise ArgumentError.