### PR TITLE
Proc#with_refinements: lock-free memo read with imemo

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -14036,8 +14036,8 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     RB_OBJ_WRITE(iseq, &load_body->parent_iseq, parent_iseq);
     RB_OBJ_WRITE(iseq, &load_body->local_iseq, local_iseq);
     /* For block iseqs mandatory_only_iseq was dumped as absent (index -1), so
-     * this writes NULL, which also leaves opt.refinement_memo NULL (the union
-     * members share representation; see the opt comment in vm_core.h).  A copy
+     * this writes NULL (all-zero bits), which also leaves opt.refinement_memo
+     * as 0/Qfalse (both members are pointer-sized; see vm_core.h).  A copy
      * thus starts with no with_refinements memo. */
     RB_OBJ_WRITE(iseq, &load_body->opt.mandatory_only_iseq, mandatory_only_iseq);
 

--- a/compile.c
+++ b/compile.c
@@ -14036,8 +14036,8 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     RB_OBJ_WRITE(iseq, &load_body->parent_iseq, parent_iseq);
     RB_OBJ_WRITE(iseq, &load_body->local_iseq, local_iseq);
     /* For block iseqs mandatory_only_iseq was dumped as absent (index -1), so
-     * this writes NULL (all-zero bits), which also leaves opt.refinement_memo
-     * as 0/Qfalse (both members are pointer-sized; see vm_core.h).  A copy
+     * this writes NULL, which also leaves opt.refinement_memo NULL (the union
+     * members share representation; see the opt comment in vm_core.h).  A copy
      * thus starts with no with_refinements memo. */
     RB_OBJ_WRITE(iseq, &load_body->opt.mandatory_only_iseq, mandatory_only_iseq);
 

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -406,7 +406,7 @@ count_tdata_objects(int argc, VALUE *argv, VALUE self)
     return hash;
 }
 
-static ID imemo_type_ids[IMEMO_MASK+1];
+static ID imemo_type_ids[imemo_refinement_memo+1];
 
 static void
 count_imemo_objects_i(VALUE v, void *data)
@@ -475,6 +475,7 @@ count_imemo_objects(int argc, VALUE *argv, VALUE self)
         INIT_IMEMO_TYPE_ID(imemo_fields);
         INIT_IMEMO_TYPE_ID(imemo_subclasses);
         INIT_IMEMO_TYPE_ID(imemo_cdhash);
+        INIT_IMEMO_TYPE_ID(imemo_refinement_memo);
 #undef INIT_IMEMO_TYPE_ID
     }
 

--- a/gc.c
+++ b/gc.c
@@ -1330,6 +1330,7 @@ rb_gc_imemo_needs_cleanup_p(VALUE obj)
       case imemo_callcache:
       case imemo_throw_data:
       case imemo_cvar_entry:
+      case imemo_refinement_memo:
         return false;
 
       case imemo_env:

--- a/imemo.c
+++ b/imemo.c
@@ -33,6 +33,7 @@ rb_imemo_name(enum imemo_type type)
         IMEMO_NAME(fields);
         IMEMO_NAME(subclasses);
         IMEMO_NAME(cdhash);
+        IMEMO_NAME(refinement_memo);
 #undef IMEMO_NAME
     }
     rb_bug("unreachable");
@@ -45,7 +46,8 @@ rb_imemo_name(enum imemo_type type)
 VALUE
 rb_imemo_new(enum imemo_type type, VALUE v0, size_t size, bool is_shareable)
 {
-    VALUE flags = T_IMEMO | (type << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
+    VALUE flags = T_IMEMO | ((type & IMEMO_MASK) << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
+    if (type & 0x10) flags |= IMEMO_TYPE_EXT_BIT;
     return rb_newobj_of(v0, flags, size);
 }
 
@@ -320,6 +322,8 @@ rb_imemo_memsize(VALUE obj)
       case imemo_cdhash:
         size += st_memsize(rb_imemo_cdhash_tbl(obj)) - sizeof(st_table);
 
+        break;
+      case imemo_refinement_memo:
         break;
       default:
         rb_bug("unreachable");
@@ -601,6 +605,14 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
         }
         break;
       }
+      case imemo_refinement_memo: {
+        struct rb_iseq_refinement_memo *memo = (struct rb_iseq_refinement_memo *)obj;
+        rb_gc_mark_and_move(&memo->base_cref);
+        rb_gc_mark_and_move(&memo->mods);
+        rb_gc_mark_and_move(&memo->copied_iseq);
+        rb_gc_mark_and_move(&memo->cref);
+        break;
+      }
       default:
         rb_bug("unreachable");
     }
@@ -718,6 +730,8 @@ rb_imemo_free(VALUE obj)
         st_free_embedded_table(rb_imemo_cdhash_tbl(obj));
         RB_DEBUG_COUNTER_INC(obj_imemo_cdhash);
 
+        break;
+      case imemo_refinement_memo:
         break;
       default:
         rb_bug("unreachable");

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -113,7 +113,7 @@ struct rb_imemo_cdhash {
 struct rb_iseq_refinement_memo {
     VALUE flags;
     VALUE base_cref;     /* key: captured cref of the source proc */
-    VALUE mods;          /* key: frozen Array of module objects */
+    VALUE mods;          /* key: module (argc=1) or frozen Array (argc>=2) */
     VALUE copied_iseq;   /* value: copied iseq with independent caches */
     VALUE cref;          /* value: cref with refinements activated */
 };

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -17,7 +17,11 @@
 
 #define IMEMO_MASK   0x0f
 
-/* FL_USER0 to FL_USER3 is for type */
+/* FL_USER0 to FL_USER3 is for type (low 4 bits).
+ * Types >= 16 store the 5th bit non-contiguously in IMEMO_TYPE_EXT_BIT
+ * to avoid encroaching on IMEMO_FL_USER0 (FL_USER4). */
+#define IMEMO_TYPE_EXT_BIT FL_USER11
+
 #define IMEMO_FL_USHIFT (FL_USHIFT + 4)
 #define IMEMO_FL_USER0 FL_USER4
 #define IMEMO_FL_USER1 FL_USER5
@@ -44,6 +48,7 @@ enum imemo_type {
     imemo_fields         = 13,
     imemo_subclasses     = 14,
     imemo_cdhash         = 15,
+    imemo_refinement_memo = 16,
 };
 
 /* CREF (Class REFerence) is defined in method.h */
@@ -103,6 +108,14 @@ struct rb_imemo_tmpbuf_struct {
 struct rb_imemo_cdhash {
     VALUE flags;
     st_table tbl;
+};
+
+struct rb_iseq_refinement_memo {
+    VALUE flags;
+    VALUE base_cref;     /* key: captured cref of the source proc */
+    VALUE mods;          /* key: frozen Array of module objects */
+    VALUE copied_iseq;   /* value: copied iseq with independent caches */
+    VALUE cref;          /* value: cref with refinements activated */
 };
 
 /* Set on imemo_memo when u3 holds a VALUE that GC must mark.
@@ -165,18 +178,24 @@ RUBY_SYMBOL_EXPORT_END
 static inline enum imemo_type
 imemo_type(VALUE imemo)
 {
-    return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
+    VALUE flags = RBASIC(imemo)->flags;
+    unsigned int lo = (flags >> FL_USHIFT) & IMEMO_MASK;
+    unsigned int hi = (flags & IMEMO_TYPE_EXT_BIT) ? 0x10 : 0;
+    return (enum imemo_type)(lo | hi);
 }
 
 static inline int
 imemo_type_p(VALUE imemo, enum imemo_type imemo_type)
 {
     if (LIKELY(!RB_SPECIAL_CONST_P(imemo))) {
-        /* fixed at compile time if imemo_type is given. */
-        const VALUE mask = (IMEMO_MASK << FL_USHIFT) | RUBY_T_MASK;
-        const VALUE expected_type = (imemo_type << FL_USHIFT) | T_IMEMO;
-        /* fixed at runtime. */
-        return expected_type == (RBASIC(imemo)->flags & mask);
+        VALUE flags = RBASIC(imemo)->flags;
+        /* Check T_IMEMO type tag and low 4 bits of imemo type. */
+        const VALUE lo_mask = (IMEMO_MASK << FL_USHIFT) | RUBY_T_MASK;
+        const VALUE expected_lo = ((imemo_type & IMEMO_MASK) << FL_USHIFT) | T_IMEMO;
+        if ((flags & lo_mask) != expected_lo) return 0;
+        /* Check the extension bit for types >= 16. */
+        unsigned int has_ext = (flags & IMEMO_TYPE_EXT_BIT) ? 0x10 : 0;
+        return has_ext == (unsigned int)(imemo_type & 0x10);
     }
     else {
         return 0;

--- a/iseq.c
+++ b/iseq.c
@@ -371,6 +371,7 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_c
     memo->cref = cref;
 
     rb_obj_hide(memo_obj);
+    FL_SET_RAW(memo_obj, RUBY_FL_SHAREABLE);
 
     RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)copied_iseq);
     RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)cref);

--- a/iseq.c
+++ b/iseq.c
@@ -264,10 +264,16 @@ iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
                                VALUE base_cref, long argc, const VALUE *mods)
 {
     if (memo->base_cref != base_cref) return false;
-    if (RARRAY_LEN(memo->mods) != argc) return false;
-    const VALUE *a = RARRAY_CONST_PTR(memo->mods);
-    for (long i = 0; i < argc; i++) {
-        if (a[i] != mods[i]) return false;
+    /* Single module is stored directly; multiple modules as a frozen Array. */
+    if (RB_TYPE_P(memo->mods, T_ARRAY)) {
+        if (RARRAY_LEN(memo->mods) != argc) return false;
+        const VALUE *a = RARRAY_CONST_PTR(memo->mods);
+        for (long i = 0; i < argc; i++) {
+            if (a[i] != mods[i]) return false;
+        }
+    }
+    else {
+        if (argc != 1 || memo->mods != mods[0]) return false;
     }
     return true;
 }
@@ -303,9 +309,15 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
                               long argc, const VALUE *mods,
                               const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
 {
-    VALUE mods_ary = rb_ary_new_from_values(argc, mods);
-    OBJ_FREEZE(mods_ary);
-    RB_OBJ_SET_SHAREABLE(mods_ary);
+    VALUE mods_val;
+    if (argc == 1) {
+        mods_val = mods[0];
+    }
+    else {
+        mods_val = rb_ary_new_from_values(argc, mods);
+        OBJ_FREEZE(mods_val);
+        RB_OBJ_SET_SHAREABLE(mods_val);
+    }
 
     VALUE memo_obj = rb_imemo_new(imemo_refinement_memo, 0,
                                   sizeof(struct rb_iseq_refinement_memo), true);
@@ -313,7 +325,7 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
         (struct rb_iseq_refinement_memo *)memo_obj;
 
     RB_OBJ_WRITE(memo_obj, &memo->base_cref, base_cref);
-    RB_OBJ_WRITE(memo_obj, &memo->mods, mods_ary);
+    RB_OBJ_WRITE(memo_obj, &memo->mods, mods_val);
     RB_OBJ_WRITE(memo_obj, &memo->copied_iseq, (VALUE)copied_iseq);
     RB_OBJ_WRITE(memo_obj, &memo->cref, (VALUE)cref);
 

--- a/iseq.c
+++ b/iseq.c
@@ -261,30 +261,29 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
 static bool
 iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
-                               VALUE base_cref, VALUE mods_ary)
+                               VALUE base_cref, long argc, const VALUE *mods)
 {
     if (memo->base_cref != base_cref) return false;
-    long argc = RARRAY_LEN(mods_ary);
     if (RARRAY_LEN(memo->mods) != argc) return false;
     const VALUE *a = RARRAY_CONST_PTR(memo->mods);
-    const VALUE *b = RARRAY_CONST_PTR(mods_ary);
     for (long i = 0; i < argc; i++) {
-        if (a[i] != b[i]) return false;
+        if (a[i] != mods[i]) return false;
     }
     return true;
 }
 
-/* Lock-free lookup: acquire-load the memo pointer, read immutable fields. */
+/* Lock-free lookup: acquire-load the memo pointer, read immutable fields.
+ * No allocation on this path so it never triggers GC. */
 bool
 rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
-                               VALUE mods_ary,
+                               long argc, const VALUE *mods,
                                const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
 {
     const struct rb_iseq_refinement_memo *memo =
         (const struct rb_iseq_refinement_memo *)rbimpl_atomic_ptr_load(
             (void **)&ISEQ_BODY(src_iseq)->opt.refinement_memo, RBIMPL_ATOMIC_ACQUIRE);
     if (memo) {
-        if (iseq_refinement_memo_key_match(memo, base_cref, mods_ary)) {
+        if (iseq_refinement_memo_key_match(memo, base_cref, argc, mods)) {
             *iseq_out = (const rb_iseq_t *)memo->copied_iseq;
             *cref_out = (const rb_cref_t *)memo->cref;
             return true;
@@ -301,9 +300,12 @@ rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
  * Must be called under RB_VM_LOCKING(). */
 void
 rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
-                              VALUE mods_ary,
+                              long argc, const VALUE *mods,
                               const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
 {
+    VALUE mods_ary = rb_ary_new_from_values(argc, mods);
+    OBJ_FREEZE(mods_ary);
+
     VALUE memo_obj = rb_imemo_new(imemo_refinement_memo, 0,
                                   sizeof(struct rb_iseq_refinement_memo), true);
     struct rb_iseq_refinement_memo *memo =

--- a/iseq.c
+++ b/iseq.c
@@ -37,6 +37,7 @@
 #include "internal/thread.h"
 #include "internal/variable.h"
 #include "iseq.h"
+#include "ruby/atomic.h"
 #include "ruby/util.h"
 #include "vm_core.h"
 #include "ractor_core.h"
@@ -235,9 +236,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
         compile_data_free(ISEQ_COMPILE_DATA(iseq));
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
-        /* refinement_memo shares a slot with mandatory_only_iseq (a GC object,
-         * not owned here); only block iseqs hold a memo to free. */
-        if (body->type == ISEQ_TYPE_BLOCK) iseq_refinement_memo_free(body->opt.refinement_memo);
+        /* refinement_memo is a GC-managed T_DATA; no manual free needed. */
         SIZED_FREE(body);
     }
 
@@ -252,8 +251,14 @@ rb_iseq_free(const rb_iseq_t *iseq)
  * keyed by (base_cref, modules).  Repeatedly calling with_refinements on the
  * same proc with the same modules then reuses the copy instead of rebuilding it.
  * Sharing a copy is safe because all results for one key run under the same
- * refinement set, so their inline caches resolve identically.  The memo is owned
- * by the source iseq, so its entries live exactly as long as the source iseq. */
+ * refinement set, so their inline caches resolve identically.
+ *
+ * The memo is a GC-managed T_DATA object, immutable after publication.
+ * The read path (lookup) is lock-free using acquire semantics; the write path
+ * (store) runs under RB_VM_LOCKING().  When a new memo replaces the old one,
+ * the old T_DATA is no longer referenced by the iseq but stays alive as long
+ * as any lock-free reader holds its VALUE on the C stack (conservative GC
+ * pins it).  Once all readers finish, the next GC reclaims it. */
 
 struct rb_iseq_refinement_memo {
     const rb_cref_t *base_cref;     /* key: captured cref of the source proc */
@@ -261,6 +266,55 @@ struct rb_iseq_refinement_memo {
     VALUE *mods;                    /* key: argc module objects (heap-allocated) */
     const rb_iseq_t *copied_iseq;   /* value: copied iseq with independent caches */
     const rb_cref_t *cref;          /* value: cref with refinements activated */
+};
+
+static void
+refinement_memo_mark(void *ptr)
+{
+    struct rb_iseq_refinement_memo *memo = ptr;
+    if (memo->base_cref) rb_gc_mark_movable((VALUE)memo->base_cref);
+    if (memo->cref) rb_gc_mark_movable((VALUE)memo->cref);
+    if (memo->copied_iseq) rb_gc_mark_movable((VALUE)memo->copied_iseq);
+    for (long i = 0; i < memo->argc; i++) {
+        rb_gc_mark_movable(memo->mods[i]);
+    }
+}
+
+static void
+refinement_memo_compact(void *ptr)
+{
+    struct rb_iseq_refinement_memo *memo = ptr;
+    if (memo->base_cref) memo->base_cref = (const rb_cref_t *)rb_gc_location((VALUE)memo->base_cref);
+    if (memo->cref) memo->cref = (const rb_cref_t *)rb_gc_location((VALUE)memo->cref);
+    if (memo->copied_iseq) memo->copied_iseq = (const rb_iseq_t *)rb_gc_location((VALUE)memo->copied_iseq);
+    for (long i = 0; i < memo->argc; i++) {
+        memo->mods[i] = rb_gc_location(memo->mods[i]);
+    }
+}
+
+static void
+refinement_memo_free(void *ptr)
+{
+    struct rb_iseq_refinement_memo *memo = ptr;
+    ruby_xfree(memo->mods);
+}
+
+static size_t
+refinement_memo_memsize(const void *ptr)
+{
+    const struct rb_iseq_refinement_memo *memo = ptr;
+    return sizeof(*memo) + memo->argc * sizeof(VALUE);
+}
+
+static const rb_data_type_t refinement_memo_type = {
+    .wrap_struct_name = "refinement_memo",
+    .function = {
+        .dmark = refinement_memo_mark,
+        .dfree = refinement_memo_free,
+        .dsize = refinement_memo_memsize,
+        .dcompact = refinement_memo_compact,
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static bool
@@ -274,14 +328,16 @@ iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
     return true;
 }
 
-/* On a key hit, fill *iseq_out / *cref_out and return true; otherwise false. */
+/* Lock-free lookup: acquire-load the memo VALUE, read immutable fields. */
 bool
 rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
                                long argc, const VALUE *mods,
                                const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
 {
-    const struct rb_iseq_refinement_memo *memo = ISEQ_BODY(src_iseq)->opt.refinement_memo;
-    if (memo) {
+    VALUE memo_val = rbimpl_atomic_value_load(
+        &ISEQ_BODY(src_iseq)->opt.refinement_memo, RBIMPL_ATOMIC_ACQUIRE);
+    if (memo_val) {
+        const struct rb_iseq_refinement_memo *memo = RTYPEDDATA_DATA(memo_val);
         if (iseq_refinement_memo_key_match(memo, base_cref, argc, mods)) {
             *iseq_out = memo->copied_iseq;
             *cref_out = memo->cref;
@@ -295,59 +351,38 @@ rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_
     return false;
 }
 
-/* Replace the single memo entry with the given key/value (overwriting any
- * previous entry). */
+/* Allocate a new immutable T_DATA memo and publish it with release semantics.
+ * Must be called under RB_VM_LOCKING(). */
 void
 rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
                               long argc, const VALUE *mods,
                               const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
 {
-    /* Allocate the key array up front: this (and ZALLOC below) can trigger a
-     * GC, which marks the live memo through its source iseq.  By keeping the
-     * memo consistent (argc matches mods) whenever it is reachable from
-     * body->opt.refinement_memo, the mark never sees argc > 0 with a stale/NULL
-     * mods. */
     VALUE *new_mods = ALLOC_N(VALUE, argc);
     MEMCPY(new_mods, mods, VALUE, argc);
 
-    struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
-    /* The memo shares storage with mandatory_only_iseq, discriminated by the
-     * iseq type; with_refinements sources are always block iseqs. */
-    VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
-    struct rb_iseq_refinement_memo *memo = body->opt.refinement_memo;
-    if (memo == NULL) {
-        /* Zeroed (argc == 0, mods == NULL), so it is safe to mark before it is
-         * fully populated below. */
-        memo = ZALLOC(struct rb_iseq_refinement_memo);
-        body->opt.refinement_memo = memo;
-    }
-    else {
-        ruby_xfree(memo->mods);
-    }
-    /* Plain stores from here on (no allocation, no GC): the memo transitions
-     * directly from its previous consistent state to the new one. */
+    struct rb_iseq_refinement_memo *memo;
+    VALUE memo_obj = TypedData_Make_Struct(
+        0, struct rb_iseq_refinement_memo, &refinement_memo_type, memo);
     memo->base_cref = base_cref;
     memo->argc = argc;
     memo->mods = new_mods;
     memo->copied_iseq = copied_iseq;
     memo->cref = cref;
 
-    /* src_iseq now references these objects through the memo. */
-    RB_OBJ_WRITTEN(src_iseq, Qundef, copied_iseq);
-    RB_OBJ_WRITTEN(src_iseq, Qundef, (VALUE)cref);
-    if (base_cref) RB_OBJ_WRITTEN(src_iseq, Qundef, (VALUE)base_cref);
-    for (long i = 0; i < argc; i++) {
-        if (!SPECIAL_CONST_P(mods[i])) RB_OBJ_WRITTEN(src_iseq, Qundef, mods[i]);
-    }
-}
+    rb_obj_hide(memo_obj);
 
-static void
-iseq_refinement_memo_free(struct rb_iseq_refinement_memo *memo)
-{
-    if (memo) {
-        ruby_xfree(memo->mods);
-        ruby_xfree(memo);
+    RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)copied_iseq);
+    RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)cref);
+    if (base_cref) RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)base_cref);
+    for (long i = 0; i < argc; i++) {
+        if (!SPECIAL_CONST_P(mods[i])) RB_OBJ_WRITTEN(memo_obj, Qundef, mods[i]);
     }
+
+    struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
+    VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
+    rbimpl_atomic_value_store(&body->opt.refinement_memo, memo_obj, RBIMPL_ATOMIC_RELEASE);
+    RB_OBJ_WRITTEN(src_iseq, Qundef, memo_obj);
 }
 
 typedef VALUE iseq_value_itr_t(void *ctx, VALUE obj);
@@ -496,13 +531,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
          * the iseq type selects which one is live. */
         if (body->type == ISEQ_TYPE_BLOCK) {
             if (body->opt.refinement_memo) {
-                struct rb_iseq_refinement_memo *memo = body->opt.refinement_memo;
-                if (memo->base_cref) rb_gc_mark_and_move((VALUE *)&memo->base_cref);
-                if (memo->cref) rb_gc_mark_and_move((VALUE *)&memo->cref);
-                if (memo->copied_iseq) rb_gc_mark_and_move_ptr(&memo->copied_iseq);
-                for (long i = 0; i < memo->argc; i++) {
-                    rb_gc_mark_and_move(&memo->mods[i]);
-                }
+                rb_gc_mark_and_move(&body->opt.refinement_memo);
             }
         }
         else if (body->opt.mandatory_only_iseq) {
@@ -651,12 +680,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += body->ci_size * sizeof(struct rb_call_data);
         // TODO: should we count imemo_callinfo?
 
-        /* refinement_memo shares a slot with mandatory_only_iseq; only block
-         * iseqs hold a memo. */
-        if (body->type == ISEQ_TYPE_BLOCK && body->opt.refinement_memo) {
-            size += sizeof(struct rb_iseq_refinement_memo);
-            size += body->opt.refinement_memo->argc * sizeof(VALUE);
-        }
+        /* refinement_memo is a GC-managed T_DATA; its dsize reports its own size. */
     }
 
     compile_data = ISEQ_COMPILE_DATA(iseq);

--- a/iseq.c
+++ b/iseq.c
@@ -182,8 +182,6 @@ rb_iseq_local_hooks(const rb_iseq_t *iseq, rb_ractor_t *r, bool create)
     return hook_list;
 }
 
-static void iseq_refinement_memo_free(struct rb_iseq_refinement_memo *memo);
-
 void
 rb_iseq_free(const rb_iseq_t *iseq)
 {
@@ -236,7 +234,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
 
         compile_data_free(ISEQ_COMPILE_DATA(iseq));
         if (body->outer_variables) rb_id_table_free(body->outer_variables);
-        /* refinement_memo is a GC-managed T_DATA; no manual free needed. */
+        /* refinement_memo is a GC-managed imemo; no manual free needed. */
         SIZED_FREE(body);
     }
 
@@ -253,94 +251,42 @@ rb_iseq_free(const rb_iseq_t *iseq)
  * Sharing a copy is safe because all results for one key run under the same
  * refinement set, so their inline caches resolve identically.
  *
- * The memo is a GC-managed T_DATA object, immutable after publication.
- * The read path (lookup) is lock-free using acquire semantics; the write path
- * (store) runs under RB_VM_LOCKING().  When a new memo replaces the old one,
- * the old T_DATA is no longer referenced by the iseq but stays alive as long
- * as any lock-free reader holds its VALUE on the C stack (conservative GC
- * pins it).  Once all readers finish, the next GC reclaims it. */
-
-struct rb_iseq_refinement_memo {
-    const rb_cref_t *base_cref;     /* key: captured cref of the source proc */
-    long argc;                      /* key: number of modules */
-    VALUE *mods;                    /* key: argc module objects (heap-allocated) */
-    const rb_iseq_t *copied_iseq;   /* value: copied iseq with independent caches */
-    const rb_cref_t *cref;          /* value: cref with refinements activated */
-};
-
-static void
-refinement_memo_mark(void *ptr)
-{
-    struct rb_iseq_refinement_memo *memo = ptr;
-    if (memo->base_cref) rb_gc_mark_movable((VALUE)memo->base_cref);
-    if (memo->cref) rb_gc_mark_movable((VALUE)memo->cref);
-    if (memo->copied_iseq) rb_gc_mark_movable((VALUE)memo->copied_iseq);
-    for (long i = 0; i < memo->argc; i++) {
-        rb_gc_mark_movable(memo->mods[i]);
-    }
-}
-
-static void
-refinement_memo_compact(void *ptr)
-{
-    struct rb_iseq_refinement_memo *memo = ptr;
-    if (memo->base_cref) memo->base_cref = (const rb_cref_t *)rb_gc_location((VALUE)memo->base_cref);
-    if (memo->cref) memo->cref = (const rb_cref_t *)rb_gc_location((VALUE)memo->cref);
-    if (memo->copied_iseq) memo->copied_iseq = (const rb_iseq_t *)rb_gc_location((VALUE)memo->copied_iseq);
-    for (long i = 0; i < memo->argc; i++) {
-        memo->mods[i] = rb_gc_location(memo->mods[i]);
-    }
-}
-
-static void
-refinement_memo_free(void *ptr)
-{
-    struct rb_iseq_refinement_memo *memo = ptr;
-    ruby_xfree(memo->mods);
-}
-
-static size_t
-refinement_memo_memsize(const void *ptr)
-{
-    const struct rb_iseq_refinement_memo *memo = ptr;
-    return sizeof(*memo) + memo->argc * sizeof(VALUE);
-}
-
-static const rb_data_type_t refinement_memo_type = {
-    .wrap_struct_name = "refinement_memo",
-    .function = {
-        .dmark = refinement_memo_mark,
-        .dfree = refinement_memo_free,
-        .dsize = refinement_memo_memsize,
-        .dcompact = refinement_memo_compact,
-    },
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
-};
+ * The memo is a GC-managed imemo (imemo_refinement_memo), immutable after
+ * publication.  The read path (lookup) is lock-free using acquire semantics;
+ * the write path (store) runs under RB_VM_LOCKING().  When a new memo replaces
+ * the old one, the old imemo is no longer referenced by the iseq but stays
+ * alive as long as any lock-free reader holds its VALUE on the C stack
+ * (conservative GC pins it).  Once all readers finish, the next GC reclaims
+ * it. */
 
 static bool
 iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
-                               const rb_cref_t *base_cref, long argc, const VALUE *mods)
+                               VALUE base_cref, VALUE mods_ary)
 {
-    if (memo->base_cref != base_cref || memo->argc != argc) return false;
+    if (memo->base_cref != base_cref) return false;
+    long argc = RARRAY_LEN(mods_ary);
+    if (RARRAY_LEN(memo->mods) != argc) return false;
+    const VALUE *a = RARRAY_CONST_PTR(memo->mods);
+    const VALUE *b = RARRAY_CONST_PTR(mods_ary);
     for (long i = 0; i < argc; i++) {
-        if (memo->mods[i] != mods[i]) return false;
+        if (a[i] != b[i]) return false;
     }
     return true;
 }
 
-/* Lock-free lookup: acquire-load the memo VALUE, read immutable fields. */
+/* Lock-free lookup: acquire-load the memo pointer, read immutable fields. */
 bool
-rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
-                               long argc, const VALUE *mods,
+rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
+                               VALUE mods_ary,
                                const rb_iseq_t **iseq_out, const rb_cref_t **cref_out)
 {
-    VALUE memo_val = rbimpl_atomic_value_load(
-        &ISEQ_BODY(src_iseq)->opt.refinement_memo, RBIMPL_ATOMIC_ACQUIRE);
-    if (memo_val) {
-        const struct rb_iseq_refinement_memo *memo = RTYPEDDATA_DATA(memo_val);
-        if (iseq_refinement_memo_key_match(memo, base_cref, argc, mods)) {
-            *iseq_out = memo->copied_iseq;
-            *cref_out = memo->cref;
+    const struct rb_iseq_refinement_memo *memo =
+        (const struct rb_iseq_refinement_memo *)rbimpl_atomic_ptr_load(
+            (void **)&ISEQ_BODY(src_iseq)->opt.refinement_memo, RBIMPL_ATOMIC_ACQUIRE);
+    if (memo) {
+        if (iseq_refinement_memo_key_match(memo, base_cref, mods_ary)) {
+            *iseq_out = (const rb_iseq_t *)memo->copied_iseq;
+            *cref_out = (const rb_cref_t *)memo->cref;
             return true;
         }
         rb_category_warn(
@@ -351,38 +297,26 @@ rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_
     return false;
 }
 
-/* Allocate a new immutable T_DATA memo and publish it with release semantics.
+/* Allocate a new immutable imemo memo and publish it with release semantics.
  * Must be called under RB_VM_LOCKING(). */
 void
-rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
-                              long argc, const VALUE *mods,
+rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
+                              VALUE mods_ary,
                               const rb_iseq_t *copied_iseq, const rb_cref_t *cref)
 {
-    VALUE *new_mods = ALLOC_N(VALUE, argc);
-    MEMCPY(new_mods, mods, VALUE, argc);
+    VALUE memo_obj = rb_imemo_new(imemo_refinement_memo, 0,
+                                  sizeof(struct rb_iseq_refinement_memo), true);
+    struct rb_iseq_refinement_memo *memo =
+        (struct rb_iseq_refinement_memo *)memo_obj;
 
-    struct rb_iseq_refinement_memo *memo;
-    VALUE memo_obj = TypedData_Make_Struct(
-        0, struct rb_iseq_refinement_memo, &refinement_memo_type, memo);
-    memo->base_cref = base_cref;
-    memo->argc = argc;
-    memo->mods = new_mods;
-    memo->copied_iseq = copied_iseq;
-    memo->cref = cref;
-
-    rb_obj_hide(memo_obj);
-    FL_SET_RAW(memo_obj, RUBY_FL_SHAREABLE);
-
-    RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)copied_iseq);
-    RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)cref);
-    if (base_cref) RB_OBJ_WRITTEN(memo_obj, Qundef, (VALUE)base_cref);
-    for (long i = 0; i < argc; i++) {
-        if (!SPECIAL_CONST_P(mods[i])) RB_OBJ_WRITTEN(memo_obj, Qundef, mods[i]);
-    }
+    RB_OBJ_WRITE(memo_obj, &memo->base_cref, base_cref);
+    RB_OBJ_WRITE(memo_obj, &memo->mods, mods_ary);
+    RB_OBJ_WRITE(memo_obj, &memo->copied_iseq, (VALUE)copied_iseq);
+    RB_OBJ_WRITE(memo_obj, &memo->cref, (VALUE)cref);
 
     struct rb_iseq_constant_body *body = ISEQ_BODY(src_iseq);
     VM_ASSERT(body->type == ISEQ_TYPE_BLOCK);
-    rbimpl_atomic_value_store(&body->opt.refinement_memo, memo_obj, RBIMPL_ATOMIC_RELEASE);
+    rbimpl_atomic_ptr_store((volatile void **)&body->opt.refinement_memo, memo, RBIMPL_ATOMIC_RELEASE);
     RB_OBJ_WRITTEN(src_iseq, Qundef, memo_obj);
 }
 
@@ -532,7 +466,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
          * the iseq type selects which one is live. */
         if (body->type == ISEQ_TYPE_BLOCK) {
             if (body->opt.refinement_memo) {
-                rb_gc_mark_and_move(&body->opt.refinement_memo);
+                rb_gc_mark_and_move_ptr(&body->opt.refinement_memo);
             }
         }
         else if (body->opt.mandatory_only_iseq) {
@@ -681,7 +615,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
         size += body->ci_size * sizeof(struct rb_call_data);
         // TODO: should we count imemo_callinfo?
 
-        /* refinement_memo is a GC-managed T_DATA; its dsize reports its own size. */
+        /* refinement_memo is a GC-managed imemo; its memsize is reported separately. */
     }
 
     compile_data = ISEQ_COMPILE_DATA(iseq);

--- a/iseq.c
+++ b/iseq.c
@@ -305,6 +305,7 @@ rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
 {
     VALUE mods_ary = rb_ary_new_from_values(argc, mods);
     OBJ_FREEZE(mods_ary);
+    RB_OBJ_SET_SHAREABLE(mods_ary);
 
     VALUE memo_obj = rb_imemo_new(imemo_refinement_memo, 0,
                                   sizeof(struct rb_iseq_refinement_memo), true);

--- a/iseq.c
+++ b/iseq.c
@@ -279,7 +279,7 @@ iseq_refinement_memo_key_match(const struct rb_iseq_refinement_memo *memo,
 }
 
 /* Lock-free lookup: acquire-load the memo pointer, read immutable fields.
- * No allocation on this path so it never triggers GC. */
+ * On a key hit, fill *iseq_out / *cref_out and return true; otherwise false. */
 bool
 rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
                                long argc, const VALUE *mods,

--- a/proc.c
+++ b/proc.c
@@ -163,10 +163,10 @@ proc_dup(VALUE self)
 rb_cref_t *rb_vm_get_cref(const VALUE *ep);
 VALUE rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref);
 bool rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
-                                    VALUE mods_ary,
+                                    long argc, const VALUE *mods,
                                     const rb_iseq_t **iseq_out, const rb_cref_t **cref_out);
 void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
-                                   VALUE mods_ary,
+                                   long argc, const VALUE *mods,
                                    const rb_iseq_t *copied_iseq, const rb_cref_t *cref);
 
 /*
@@ -248,13 +248,10 @@ proc_with_refinements(int argc, VALUE *argv, VALUE self)
     VALUE base_cref = (VALUE)rb_vm_get_cref(src->block.as.captured.ep);
     const rb_iseq_t *src_iseq = src->block.as.captured.code.iseq;
 
-    VALUE mods_ary = rb_ary_new_from_values(argc, argv);
-    OBJ_FREEZE(mods_ary);
-
     const rb_iseq_t *new_iseq;
     const rb_cref_t *new_cref;
-    /* Lock-free memo lookup (acquire load, no lock needed on hit). */
-    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, mods_ary, &new_iseq, &new_cref)) {
+    /* Lock-free memo lookup (acquire load, no allocation, no lock needed on hit). */
+    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
         /* Memo miss: create under lock.  Redundant copies on concurrent miss
          * are harmless; the old imemo memo is reclaimed by GC. */
         RB_VM_LOCKING() {
@@ -264,7 +261,7 @@ proc_with_refinements(int argc, VALUE *argv, VALUE self)
             }
             new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
             new_cref = cref;
-            rb_iseq_refinement_memo_store(src_iseq, base_cref, mods_ary, new_iseq, new_cref);
+            rb_iseq_refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
         }
     }
 

--- a/proc.c
+++ b/proc.c
@@ -162,11 +162,11 @@ proc_dup(VALUE self)
 
 rb_cref_t *rb_vm_get_cref(const VALUE *ep);
 VALUE rb_proc_dup_with_iseq_and_cref(VALUE self, const rb_iseq_t *iseq, const rb_cref_t *cref);
-bool rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
-                                    long argc, const VALUE *mods,
+bool rb_iseq_refinement_memo_lookup(const rb_iseq_t *src_iseq, VALUE base_cref,
+                                    VALUE mods_ary,
                                     const rb_iseq_t **iseq_out, const rb_cref_t **cref_out);
-void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, const rb_cref_t *base_cref,
-                                   long argc, const VALUE *mods,
+void rb_iseq_refinement_memo_store(const rb_iseq_t *src_iseq, VALUE base_cref,
+                                   VALUE mods_ary,
                                    const rb_iseq_t *copied_iseq, const rb_cref_t *cref);
 
 /*
@@ -245,23 +245,26 @@ proc_with_refinements(int argc, VALUE *argv, VALUE self)
         Check_Type(argv[i], T_MODULE);
     }
 
-    const rb_cref_t *base_cref = rb_vm_get_cref(src->block.as.captured.ep);
+    VALUE base_cref = (VALUE)rb_vm_get_cref(src->block.as.captured.ep);
     const rb_iseq_t *src_iseq = src->block.as.captured.code.iseq;
+
+    VALUE mods_ary = rb_ary_new_from_values(argc, argv);
+    OBJ_FREEZE(mods_ary);
 
     const rb_iseq_t *new_iseq;
     const rb_cref_t *new_cref;
     /* Lock-free memo lookup (acquire load, no lock needed on hit). */
-    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
+    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, mods_ary, &new_iseq, &new_cref)) {
         /* Memo miss: create under lock.  Redundant copies on concurrent miss
-         * are harmless; the old T_DATA memo is reclaimed by GC. */
+         * are harmless; the old imemo memo is reclaimed by GC. */
         RB_VM_LOCKING() {
-            rb_cref_t *cref = rb_vm_cref_dup(base_cref);
+            rb_cref_t *cref = rb_vm_cref_dup((const rb_cref_t *)base_cref);
             for (int i = 0; i < argc; i++) {
                 rb_using_module_recursive(cref, argv[i]);
             }
             new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
             new_cref = cref;
-            rb_iseq_refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
+            rb_iseq_refinement_memo_store(src_iseq, base_cref, mods_ary, new_iseq, new_cref);
         }
     }
 

--- a/proc.c
+++ b/proc.c
@@ -252,14 +252,15 @@ proc_with_refinements(int argc, VALUE *argv, VALUE self)
     const rb_cref_t *new_cref;
     /* Lock-free memo lookup (acquire load, no allocation, no lock needed on hit). */
     if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
-        /* Memo miss: create under lock.  Redundant copies on concurrent miss
-         * are harmless; the old imemo memo is reclaimed by GC. */
+        /* IBF round-trip is expensive; do it outside the lock. */
+        new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
+        /* rb_using_module_recursive modifies shared subclass lists,
+         * so cref setup and store must be under the VM lock. */
         RB_VM_LOCKING() {
             rb_cref_t *cref = rb_vm_cref_dup((const rb_cref_t *)base_cref);
             for (int i = 0; i < argc; i++) {
                 rb_using_module_recursive(cref, argv[i]);
             }
-            new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
             new_cref = cref;
             rb_iseq_refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
         }

--- a/proc.c
+++ b/proc.c
@@ -248,35 +248,19 @@ proc_with_refinements(int argc, VALUE *argv, VALUE self)
     const rb_cref_t *base_cref = rb_vm_get_cref(src->block.as.captured.ep);
     const rb_iseq_t *src_iseq = src->block.as.captured.code.iseq;
 
-    /* Reuse the most recent {copied iseq, cref} pair if this same iseq was
-     * already given the same (base_cref, modules).  Copying the iseq is
-     * expensive, and all results for one key run under the same refinement set,
-     * so sharing the copy and its warmed caches is safe.  See the memo helpers
-     * in iseq.c. */
     const rb_iseq_t *new_iseq;
     const rb_cref_t *new_cref;
-    /* Use RB_VM_LOCKING() to synchronize refinement_memo access in multi-Ractor mode. */
-    RB_VM_LOCKING() {
-        if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
-            /* Duplicate the block's cref (keeping its current refinements) and
-             * activate the refinements of each module argument on the copy.  The
-             * cref is freshly duplicated and not referenced by any call site yet, so
-             * we use rb_using_module_recursive directly and skip the global
-             * refinement method cache flush that the top-level `using`
-             * (rb_using_module) performs. */
+    /* Lock-free memo lookup (acquire load, no lock needed on hit). */
+    if (!rb_iseq_refinement_memo_lookup(src_iseq, base_cref, argc, argv, &new_iseq, &new_cref)) {
+        /* Memo miss: create under lock.  Redundant copies on concurrent miss
+         * are harmless; the old T_DATA memo is reclaimed by GC. */
+        RB_VM_LOCKING() {
             rb_cref_t *cref = rb_vm_cref_dup(base_cref);
             for (int i = 0; i < argc; i++) {
                 rb_using_module_recursive(cref, argv[i]);
             }
-
-            /* Recursively copy the block's iseq (and its children) so the new Proc
-             * has its own inline method caches.  This is required for correctness:
-             * the VM caches refinement method resolution per call site assuming one
-             * iseq runs under a single lexical cref, so sharing the iseq would leak
-             * the refined methods into the original Proc. */
             new_iseq = rb_iseq_dup_with_independent_caches(src_iseq);
             new_cref = cref;
-
             rb_iseq_refinement_memo_store(src_iseq, base_cref, argc, argv, new_iseq, new_cref);
         }
     }

--- a/vm_core.h
+++ b/vm_core.h
@@ -555,25 +555,24 @@ struct rb_iseq_constant_body {
      *   - mandatory_only_iseq: for ISEQ_TYPE_METHOD, the body of the
      *     mandatory-only optimized variant (set only for methods that use the
      *     __builtin.mandatory_only? optimization).
-     *   - refinement_memo: for ISEQ_TYPE_BLOCK, the single-entry
-     *     Proc#with_refinements memo caching the most recent
-     *     {copied iseq, cref} pair for a given (base_cref, modules) key.  NULL
-     *     unless this block iseq has been a Proc#with_refinements source.
+     *   - refinement_memo: for ISEQ_TYPE_BLOCK, a GC-managed T_DATA
+     *     (wrapping struct rb_iseq_refinement_memo) caching the most recent
+     *     {copied iseq, cref} pair for a given (base_cref, modules) key.
+     *     0 (Qfalse) unless this block iseq has been a with_refinements source.
+     *     Accessed lock-free with acquire/release semantics; the T_DATA is
+     *     immutable after publication, and old memos are reclaimed by GC.
      * A block iseq never has a mandatory-only variant and only block iseqs are
      * with_refinements sources, so discriminate with
      * ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK.
      *
-     * Both members are pointers to structure types, so by C99 (ISO/IEC
-     * 9899:1999) 6.2.5p27 -- "All pointers to structure types shall have the
-     * same representation and alignment requirements as each other" -- storing
-     * NULL into one member makes the other read as NULL too.  IBF load relies on
-     * this: it only writes opt.mandatory_only_iseq (NULL for block iseqs), which
-     * also leaves opt.refinement_memo NULL.  Adding a non-structure-pointer
-     * member (void *, uintptr_t, ...) would break that guarantee and require
-     * writing the correct member explicitly. */
+     * Both members are pointer-sized (sizeof(VALUE) == sizeof(void *) on all
+     * CRuby targets) and zero-initialized to the same bit pattern: NULL for
+     * mandatory_only_iseq, 0/Qfalse for refinement_memo.  IBF load writes
+     * opt.mandatory_only_iseq = NULL for block iseqs, which also leaves
+     * opt.refinement_memo as 0. */
     union {
         const rb_iseq_t *mandatory_only_iseq;
-        struct rb_iseq_refinement_memo *refinement_memo;
+        VALUE refinement_memo;
     } opt;
 
 #if USE_YJIT || USE_ZJIT

--- a/vm_core.h
+++ b/vm_core.h
@@ -555,24 +555,27 @@ struct rb_iseq_constant_body {
      *   - mandatory_only_iseq: for ISEQ_TYPE_METHOD, the body of the
      *     mandatory-only optimized variant (set only for methods that use the
      *     __builtin.mandatory_only? optimization).
-     *   - refinement_memo: for ISEQ_TYPE_BLOCK, a GC-managed T_DATA
-     *     (wrapping struct rb_iseq_refinement_memo) caching the most recent
-     *     {copied iseq, cref} pair for a given (base_cref, modules) key.
-     *     0 (Qfalse) unless this block iseq has been a with_refinements source.
-     *     Accessed lock-free with acquire/release semantics; the T_DATA is
+     *   - refinement_memo: for ISEQ_TYPE_BLOCK, the single-entry
+     *     Proc#with_refinements memo (imemo_refinement_memo) caching the most
+     *     recent {copied iseq, cref} pair for a given (base_cref, modules) key.
+     *     NULL unless this block iseq has been a Proc#with_refinements source.
+     *     Accessed lock-free with acquire/release semantics; the imemo is
      *     immutable after publication, and old memos are reclaimed by GC.
      * A block iseq never has a mandatory-only variant and only block iseqs are
      * with_refinements sources, so discriminate with
      * ISEQ_BODY(iseq)->type == ISEQ_TYPE_BLOCK.
      *
-     * Both members are pointer-sized (sizeof(VALUE) == sizeof(void *) on all
-     * CRuby targets) and zero-initialized to the same bit pattern: NULL for
-     * mandatory_only_iseq, 0/Qfalse for refinement_memo.  IBF load writes
-     * opt.mandatory_only_iseq = NULL for block iseqs, which also leaves
-     * opt.refinement_memo as 0. */
+     * Both members are pointers to structure types, so by C99 (ISO/IEC
+     * 9899:1999) 6.2.5p27 -- "All pointers to structure types shall have the
+     * same representation and alignment requirements as each other" -- storing
+     * NULL into one member makes the other read as NULL too.  IBF load relies on
+     * this: it only writes opt.mandatory_only_iseq (NULL for block iseqs), which
+     * also leaves opt.refinement_memo NULL.  Adding a non-structure-pointer
+     * member (void *, uintptr_t, ...) would break that guarantee and require
+     * writing the correct member explicitly. */
     union {
         const rb_iseq_t *mandatory_only_iseq;
-        VALUE refinement_memo;
+        struct rb_iseq_refinement_memo *refinement_memo;
     } opt;
 
 #if USE_YJIT || USE_ZJIT


### PR DESCRIPTION
Make the refinement_memo read path (memo hit) completely lock-free
by imemo and using acquire/release memory ordering for publication.

Add `IMEMO_TYPE_EXT_BIT` to support more than 16 imemo types.

## Benchmark: lock overhead on memo hit path

Measured with [bench_lock_overhead.rb](https://gist.github.com/shugo/b58640e4b6c6df76f857159d79a5eb74
) (2M iterations, best of 3 runs).

|  | original (locked) | imemo (lock-free) |
|--|-------------------|-------------------|
| Proc#call (baseline) | 57.2 ns | 51.6 ns |
| with_refinements (1 Ractor) | 130.1 ns | 116.9 ns |
| with_refinements (multi Ractor) | 146.9 ns | 117.9 ns |
| Lock overhead (multi − single) | 15.6 ns (1.11x) | 1.0 ns (1.00x) |

- **Single-Ractor**: performance is comparable. The absolute numbers differ across builds due to code layout changes and are not directly comparable.
- **Multi-Ractor**: the lock overhead is reduced from ~16 ns to ~1 ns per call.

## Memory comparison: original (locked) vs imemo (lock-free)

| argc | original (malloc) | imemo (VWA slots) | diff |
|------|-------------------|-------------------|------|
| 1 | 48 bytes | 40 bytes | -8 |
| 2 | 56 bytes | 80 bytes | +24 |
| 3 | 64 bytes | 80 bytes | +16 |
| 4 | 72 bytes | 104 bytes | +32 |
| 5 | 80 bytes | 104 bytes | +24 |

### `feature/proc-with_refinements` (original, locked)

- `ZALLOC(struct rb_iseq_refinement_memo)`: 5 fields × 8 = **40 bytes** (malloc'd)
- `ALLOC_N(VALUE, argc)`: **argc × 8 bytes** (malloc'd)
- No RVALUE slots consumed

**Total: 40 + argc × 8 bytes** (malloc only, plus malloc header overhead per allocation)

### `feature/proc-with_refinements-lock-free-imemo` (this branch)

- `imemo_refinement_memo`: **1 RVALUE slot = 40 bytes**
- mods storage:
  - argc = 1: module VALUE stored directly in the imemo field, **no extra allocation**
  - argc ≥ 2: frozen Array (VWA embedded), slot size = smallest slot ≥ `max(40, 16 + argc × 8)`

**Total (argc = 1): 40 bytes** (1 RVALUE slot)
**Total (argc ≥ 2): 40 + Array slot bytes** (2 RVALUE slots, Array slot depends on argc)

### Notes

- For argc = 1 (the common case), the imemo branch uses slightly less memory than the original. For argc ≥ 2, the
imemo branch uses more due to RVALUE slot granularity.
- The primary benefit of the imemo branch is lock-free read on the hot path, not memory reduction.
- malloc overhead (typically 16 bytes/allocation) is not included above. The original has 2 malloc allocations (struct + mods array); the imemo branch has 0 malloc allocations in all cases.

