### PR TITLE
Assert in debug builds that rb_block_call() is not passed stack data

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1481,6 +1481,32 @@ iterator_block_expired(RB_BLOCK_CALL_FUNC_ARGLIST(yielded_arg, callback_arg))
     UNREACHABLE_RETURN(Qnil);
 }
 
+#if RUBY_DEBUG
+static bool
+iterator_data_looks_like_stack_pointer(const rb_execution_context_t *ec, const void *data)
+{
+    if (RB_SPECIAL_CONST_P((VALUE)data)) return false;
+
+    int here_var;
+    const uintptr_t here  = (uintptr_t)asan_get_real_stack_addr(&here_var);
+    const uintptr_t start = (uintptr_t)ec->machine.stack_start;
+    const uintptr_t p     = (uintptr_t)data;
+    const uintptr_t lo    = start < here ? start : here;
+    const uintptr_t hi    = start < here ? here : start;
+
+    if (lo <= p && p <= hi) return true;
+
+    void *fake_beg, *fake_end;
+    if (asan_get_fake_stack_extents(asan_get_thread_fake_stack_handle(),
+                                    (VALUE)data,
+                                    ec->machine.stack_start, (void *)here,
+                                    &fake_beg, &fake_end)) {
+        return true;
+    }
+    return false;
+}
+#endif
+
 static VALUE
 rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
             struct vm_ifunc *const ifunc, bool block_noescape,
@@ -1490,6 +1516,14 @@ rb_iterate0(VALUE (* it_proc) (VALUE), VALUE data1,
     volatile VALUE retval = Qnil;
     rb_control_frame_t *volatile const cfp = ec->cfp;
     struct vm_ifunc *volatile const invalidate_ifunc = block_noescape ? ifunc : NULL;
+
+#if RUBY_DEBUG
+    if (!block_noescape && ifunc &&
+        iterator_data_looks_like_stack_pointer(ec, ifunc->data)) {
+        rb_bug("rb_block_call() was passed a pointer to C stack data as data2; "
+               "use rb_block_call_noescape() instead");
+    }
+#endif
 
     EC_PUSH_TAG(ec);
     state = EC_EXEC_TAG();


### PR DESCRIPTION
This is stacked on top of #17777 (its base is `fix/bug22019-set-intersect-segv`, not `master`), and should be reviewed/merged after it.

## What

Now that stack-backed call sites are expected to use `rb_block_call_noescape()` instead of `rb_block_call()`, add a `RUBY_DEBUG`-only assertion in `rb_iterate0()` that fires when a plain `rb_block_call()` (i.e. `block_noescape == false`) is handed a `data2` that points into the caller's C stack:

```
$ ./ruby -e 'Set[1,2,3] & [1,2]'   # if Set#& used plain rb_block_call by mistake
-e:1: [BUG] rb_block_call() was passed a pointer to C stack data as data2; use rb_block_call_noescape() instead
```

Such a site would leave a block captured by the called method pointing at a dead stack frame after the call returns (a use-after-return). The assertion catches the mistake at development time and names the fix, so future call sites that forget `rb_block_call_noescape()` are caught by CI rather than shipping a latent crash.

## ASAN-aware

The check is aware of AddressSanitizer's `detect_stack_use_after_return`, which relocates an address-taken local to a per-thread "fake stack" off the machine stack. A plain machine-stack range test would miss it (this is exactly the blind spot that made the earlier address-range heuristic fail under ASAN). It reuses the same fake-stack helpers already used by the conservative GC stack scan (`asan_get_real_stack_addr` / `asan_get_thread_fake_stack_handle` / `asan_get_fake_stack_extents` in `internal/sanitizers.h`).

## Debug-only lint, never gates behavior

This only asserts; it never changes behavior. It is a heuristic (a non-VALUE immediate that happens to alias the stack range would be a false positive), so it is `RUBY_DEBUG`-only and has no effect on release builds. An audit of every `rb_block_call` / `rb_check_block_call` / `rb_block_call2` / `rb_lambda_call` call site in the interpreter and the standard extension libraries found no site that passes such a value: every `data2` is a heap `VALUE`, a heap imemo/`MEMO`, `INT2FIX(0)` / `0` / `Qnil` (filtered by `RB_SPECIAL_CONST_P`), a `NULL` block function (no ifunc), or one of the genuine stack sites already converted to `rb_block_call_noescape()`.

## Verification

- `make btest` (2050) and the core suites (`test_enum` / `test_enumerator` / `test_set` / `test_range` / `test_array` / `test_lazy_enumerator`) pass with the assertion active in a `RUBY_DEBUG=1` build — no false positive.
- Positive control: temporarily reverting one converted site to plain `rb_block_call()` makes the assertion fire, both on a normal (gcc) build via the real machine-stack branch and on a clang ASAN build via the fake-stack branch.
- Negative control: disabling the fake-stack branch makes the ASAN build silently miss the stack pointer, reproducing the original ASAN blind spot — confirming that branch is what makes ASAN detection work.
